### PR TITLE
[feat/#12] SnackBar 컴포넌트 구현

### DIFF
--- a/app/src/main/java/com/kiero/core/designsystem/component/KieroSnackbar.kt
+++ b/app/src/main/java/com/kiero/core/designsystem/component/KieroSnackbar.kt
@@ -1,0 +1,60 @@
+package com.kiero.core.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.kiero.core.common.extension.noRippleClickable
+import com.kiero.core.designsystem.theme.KieroTheme
+
+@Composable
+fun KieroSnackbar(
+    message: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(KieroTheme.colors.gray900)
+            .noRippleClickable { }
+            .padding(16.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = message,
+            style = KieroTheme.typography.regular.body4,
+            color = KieroTheme.colors.schedule1,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun KieroSnackbarPreview() {
+    KieroTheme {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Bottom,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            KieroSnackbar(
+                message = "이 메세지는 토스트 메세지 입니다",
+                modifier = Modifier.padding(16.dp),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/kiero/core/designsystem/component/KieroSnackbar.kt
+++ b/app/src/main/java/com/kiero/core/designsystem/component/KieroSnackbar.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.kiero.core.common.extension.noRippleClickable
 import com.kiero.core.designsystem.theme.KieroTheme
 
 @Composable
@@ -29,7 +28,6 @@ fun KieroSnackbar(
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
             .background(KieroTheme.colors.gray900)
-            .noRippleClickable { }
             .padding(16.dp),
         contentAlignment = Alignment.Center
     ) {

--- a/app/src/main/java/com/kiero/presentation/main/navigation/MainAppState.kt
+++ b/app/src/main/java/com/kiero/presentation/main/navigation/MainAppState.kt
@@ -1,5 +1,7 @@
 package com.kiero.presentation.main.navigation
 
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
@@ -27,12 +29,14 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
 
 @Stable
 class MainAppState(
     val navController: NavHostController,
-    coroutineScope: CoroutineScope,
+    val snackbarHostState: SnackbarHostState,
+    val coroutineScope: CoroutineScope,
 ) {
     private val currentDestination = navController.currentBackStackEntryFlow
         .map { it.destination }
@@ -85,6 +89,15 @@ class MainAppState(
             started = SharingStarted.WhileSubscribed(5_000),
             initialValue = false
         )
+
+    fun showSnackbar(message: String) {
+        coroutineScope.launch {
+            snackbarHostState.showSnackbar(
+                message = message,
+                duration = SnackbarDuration.Short
+            )
+        }
+    }
 
     fun navigateToParent() {
         navController.navigate(ParentGraph) {
@@ -156,11 +169,13 @@ class MainAppState(
 @Composable
 fun rememberMainAppState(
     navController: NavHostController = rememberNavController(),
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     coroutineScope: CoroutineScope = rememberCoroutineScope(),
 ): MainAppState {
-    return remember(navController, coroutineScope) {
+    return remember(navController, snackbarHostState, coroutineScope) {
         MainAppState(
             navController = navController,
+            snackbarHostState = snackbarHostState,
             coroutineScope = coroutineScope
         )
     }

--- a/app/src/main/java/com/kiero/presentation/main/navigation/MainAppState.kt
+++ b/app/src/main/java/com/kiero/presentation/main/navigation/MainAppState.kt
@@ -1,6 +1,5 @@
 package com.kiero.presentation.main.navigation
 
-import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
@@ -29,14 +28,12 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 
 
 @Stable
 class MainAppState(
     val navController: NavHostController,
-    val snackbarHostState: SnackbarHostState,
-    val coroutineScope: CoroutineScope,
+    coroutineScope: CoroutineScope,
 ) {
     private val currentDestination = navController.currentBackStackEntryFlow
         .map { it.destination }
@@ -90,14 +87,6 @@ class MainAppState(
             initialValue = false
         )
 
-    fun showSnackbar(message: String) {
-        coroutineScope.launch {
-            snackbarHostState.showSnackbar(
-                message = message,
-                duration = SnackbarDuration.Short
-            )
-        }
-    }
 
     fun navigateToParent() {
         navController.navigate(ParentGraph) {
@@ -175,7 +164,6 @@ fun rememberMainAppState(
     return remember(navController, snackbarHostState, coroutineScope) {
         MainAppState(
             navController = navController,
-            snackbarHostState = snackbarHostState,
             coroutineScope = coroutineScope
         )
     }

--- a/app/src/main/java/com/kiero/presentation/main/screen/MainScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/main/screen/MainScreen.kt
@@ -5,8 +5,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -23,12 +25,18 @@ import kotlinx.collections.immutable.toImmutableList
 fun MainRoute(
     appState: MainAppState = rememberMainAppState()
 ) {
-    MainScreen(appState = appState)
+    val snackBarHostState = remember { SnackbarHostState() }
+
+    MainScreen(
+        appState = appState,
+        snackBarHostState = snackBarHostState,
+    )
 }
 
 @Composable
 fun MainScreen(
     appState: MainAppState,
+    snackBarHostState: SnackbarHostState,
     modifier: Modifier = Modifier,
 ) {
     val showParentBottomBar by appState.showParentBottomBar.collectAsStateWithLifecycle()
@@ -52,9 +60,10 @@ fun MainScreen(
     Scaffold(
         modifier = modifier.fillMaxSize(),
         snackbarHost = {
-            SnackbarHost(hostState = appState.snackbarHostState) { data ->
+            SnackbarHost(hostState = snackBarHostState) { data ->
                 KieroSnackbar(
                     message = data.visuals.message,
+                    // TODO: 디자인 확정 후 스낵바 높이 및 패딩 수정 필요
                     modifier = Modifier.padding(16.dp)
                 )
             }

--- a/app/src/main/java/com/kiero/presentation/main/screen/MainScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/main/screen/MainScreen.kt
@@ -5,13 +5,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kiero.core.designsystem.component.KieroSnackbar
 import com.kiero.presentation.main.navigation.KidMainTab
 import com.kiero.presentation.main.navigation.KieroNavHost
 import com.kiero.presentation.main.navigation.MainAppState
@@ -22,20 +21,14 @@ import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun MainRoute(
-    appState: MainAppState = rememberMainAppState(),
+    appState: MainAppState = rememberMainAppState()
 ) {
-    val snackBarHostState = remember { SnackbarHostState() }
-
-    MainScreen(
-        appState = appState,
-        snackBarHostState = snackBarHostState,
-    )
+    MainScreen(appState = appState)
 }
 
 @Composable
 fun MainScreen(
     appState: MainAppState,
-    snackBarHostState: SnackbarHostState,
     modifier: Modifier = Modifier,
 ) {
     val showParentBottomBar by appState.showParentBottomBar.collectAsStateWithLifecycle()
@@ -59,7 +52,12 @@ fun MainScreen(
     Scaffold(
         modifier = modifier.fillMaxSize(),
         snackbarHost = {
-            SnackbarHost(hostState = snackBarHostState)
+            SnackbarHost(hostState = appState.snackbarHostState) { data ->
+                KieroSnackbar(
+                    message = data.visuals.message,
+                    modifier = Modifier.padding(16.dp)
+                )
+            }
         },
         bottomBar = {
             MainBottomBar(


### PR DESCRIPTION
## ISSUE
- closed #12 

## ❗ WORK DESCRIPTION
- 공통 컴포넌트로 사용될 SnackBar 컴포넌트를 구현하였습니다.
- 전역적으로 사용하기 위해 MainAppState 내부에 SnackbarHostState를 포함시켜서 앱의 생명주기와 함께 상태를 관리하도록 하였습니다.
- MainScreen의 Scaffold에 SnackbarHost를 설정하였습니다.

<details>
<summary> <h3>사용예시</h3></summary>

## KieroNavHost 상태 주입
```kotlin
authNavGraph(
            navController = appState.navController,
            paddingValues = paddingValues,
            onShowSnackbar = appState::showSnackbar,  // 추가
            navigateUp = appState::navigateUp,
            navigateToParent = appState::navigateToParent,
            navigateToKid = appState::navigateToKid,
        )
```

## AuthNavigation 이벤트 정의 및 스크린으로의 이벤트 전파 
```kotlin
fun NavGraphBuilder.authNavGraph(
    navController: NavHostController,
    paddingValues: PaddingValues,
    onShowSnackbar: (String) -> Unit,  // 추가
    navigateUp: () -> Unit,
    navigateToParent: () -> Unit,
    navigateToKid: () -> Unit,
) {
    navigation<AuthGraph>(
        startDestination = Login
    ) {
        composable<Login> {
            AuthRoute(
                paddingValues = paddingValues,
                onShowSnackbar = onShowSnackbar,   // 추가
                navigateUp = navigateUp,
                navigateToParent = navigateToParent,
                navigateToKid = navigateToKid,
            )
        }
    }
}
```

## AuthScreen 사용자의 인터랙션을 이벤트로 변환
```
@Composable
fun AuthRoute(
    paddingValues: PaddingValues,
    onShowSnackbar: (String) -> Unit,   // 추가
    navigateUp: () -> Unit,
    navigateToParent: () -> Unit,
    navigateToKid: () -> Unit,
) {
    AuthScreen(
        paddingValues = paddingValues,
        onShowSnackbar = onShowSnackbar,   // 추가
        navigateUp = navigateUp,
        navigateToParent = navigateToParent,
        navigateToKid = navigateToKid,
        modifier = Modifier
    )
}

@Composable
fun AuthScreen(
    paddingValues: PaddingValues,
    onShowSnackbar: (String) -> Unit,   // 추가
    navigateUp: () -> Unit,
    navigateToParent: () -> Unit,
    navigateToKid: () -> Unit,
    modifier: Modifier = Modifier,
) {
    Button(
        onClick = { onShowSnackbar("이 메세지는 토스트 메세지 입니다") },   // 추가
        modifier = Modifier.fillMaxWidth()
    ) {
        Text(text = "아이 화면으로 이동")
    }
```
</details>

## 📢 TO REVIEWERS
- 스낵바에 액션 로직이 따로 없는 듯하여 단순 텍스트만 보여주는 역할로 이해했습니다. 
  그래서 Row가 아닌 Box를 이용해서 구현하였습니다.
- 현재는 패딩을 16을 줬는데 디자인 확정되면 스낵바가 나타나야 할 높이는 수정이 필요할 것 같아요.
- 이렇게 관리하는게 맞는지 잘 모르겠네요..

## 📸 SCREENSHOT
<video src="https://github.com/user-attachments/assets/f5cbe1c8-8b0e-4dad-b3ce-0a2f87e82685" width="300" />
