### PR TITLE
[feat/#15] 공통 다이얼로그 구현

### DIFF
--- a/app/src/main/java/com/kiero/core/common/extension/ModifierExt.kt
+++ b/app/src/main/java/com/kiero/core/common/extension/ModifierExt.kt
@@ -2,9 +2,13 @@ package com.kiero.core.common.extension
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.dp
 
 fun Modifier.noRippleClickable(onClick: () -> Unit): Modifier = composed {
     this.clickable(
@@ -13,4 +17,11 @@ fun Modifier.noRippleClickable(onClick: () -> Unit): Modifier = composed {
     ) {
         onClick()
     }
+}
+
+fun Modifier.forcePixelToDp(painter: Painter): Modifier {
+    return this.size(
+        width = painter.intrinsicSize.width.dp,
+        height = painter.intrinsicSize.height.dp
+    )
 }

--- a/app/src/main/java/com/kiero/core/common/util/Pixel.kt
+++ b/app/src/main/java/com/kiero/core/common/util/Pixel.kt
@@ -1,0 +1,11 @@
+package com.kiero.core.common.util
+
+import android.content.res.Resources
+
+// px을 dp로 변환
+val Int.pxToDp: Int
+    get() = (this / Resources.getSystem().displayMetrics.density).toInt()
+
+// dp를 px로 변환
+val Int.dpToPx: Int
+    get() = (this * Resources.getSystem().displayMetrics.density).toInt()

--- a/app/src/main/java/com/kiero/core/designsystem/component/dialog/KieroDialog.kt
+++ b/app/src/main/java/com/kiero/core/designsystem/component/dialog/KieroDialog.kt
@@ -139,10 +139,12 @@ private fun KieroDialogPreview() {
 
             content = {
                 Row(verticalAlignment = Alignment.CenterVertically) {
+                    val coinImage = painterResource(R.drawable.img_kid_coin)
+
                     Image(
-                        painter = painterResource(R.drawable.img_kid_coin),
+                        painter = coinImage,
                         contentDescription = null,
-                        modifier = Modifier.forcePixelToDp(painterResource(R.drawable.img_kid_coin))
+                        modifier = Modifier.forcePixelToDp(coinImage)
                     )
 
                     Spacer(modifier = Modifier.width(10.dp))

--- a/app/src/main/java/com/kiero/core/designsystem/component/dialog/KieroDialog.kt
+++ b/app/src/main/java/com/kiero/core/designsystem/component/dialog/KieroDialog.kt
@@ -81,7 +81,7 @@ fun KieroDialog(
                     )
                 }
 
-                Spacer(modifier = Modifier.height(2.dp))
+                Spacer(modifier = Modifier.height(4.dp))
 
                 Text(
                     text = title.orEmpty(),
@@ -106,7 +106,7 @@ fun KieroDialog(
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     if (cancelAction != null) {
                         cancelAction(modifier = Modifier.weight(1f))

--- a/app/src/main/java/com/kiero/core/designsystem/component/dialog/KieroDialog.kt
+++ b/app/src/main/java/com/kiero/core/designsystem/component/dialog/KieroDialog.kt
@@ -40,9 +40,7 @@ fun KieroDialog(
     modifier: Modifier = Modifier,
     title: String? = null,
     subDescription: String? = null,
-    confirmAction: DialogAction = DialogAction {
-
-    },
+    confirmAction: DialogAction,
     cancelAction: DialogAction? = null,
     properties: DialogProperties = DialogProperties(
         usePlatformDefaultWidth = false,

--- a/app/src/main/java/com/kiero/core/designsystem/component/dialog/KieroDialog.kt
+++ b/app/src/main/java/com/kiero/core/designsystem/component/dialog/KieroDialog.kt
@@ -1,0 +1,161 @@
+package com.kiero.core.designsystem.component.dialog
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.kiero.R
+import com.kiero.core.common.extension.forcePixelToDp
+import com.kiero.core.common.extension.noRippleClickable
+import com.kiero.core.designsystem.component.dialog.action.DialogAction
+import com.kiero.core.designsystem.component.dialog.action.KieroCancelAction
+import com.kiero.core.designsystem.component.dialog.action.KieroConfirmAction
+import com.kiero.core.designsystem.theme.KieroTheme
+
+@Composable
+fun KieroDialog(
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    subDescription: String? = null,
+    confirmAction: DialogAction = DialogAction {
+
+    },
+    cancelAction: DialogAction? = null,
+    properties: DialogProperties = DialogProperties(
+        usePlatformDefaultWidth = false,
+        decorFitsSystemWindows = false
+    ),
+    content: @Composable () -> Unit
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = properties,
+    ) {
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .background(color = KieroTheme.colors.gray500)
+                .padding(horizontal = 16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        color = KieroTheme.colors.gray900,
+                        shape = RoundedCornerShape(16.dp)
+                    )
+                    .padding(vertical = 12.dp, horizontal = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Row {
+                    Spacer(modifier = Modifier.weight(1f))
+
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.ic_close),
+                        contentDescription = null,
+                        tint = Color.Unspecified,
+                        modifier = Modifier
+                            .noRippleClickable(onClick = onDismiss)
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(2.dp))
+
+                Text(
+                    text = title.orEmpty(),
+                    color = KieroTheme.colors.white,
+                    style = KieroTheme.typography.semiBold.title2
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                content()
+
+                Spacer(modifier = Modifier.height(15.dp))
+
+                Text(
+                    text = subDescription.orEmpty(),
+                    color = KieroTheme.colors.gray100,
+                    style = KieroTheme.typography.regular.body3
+                )
+
+                Spacer(modifier = Modifier.height(18.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    if (cancelAction != null) {
+                        cancelAction(modifier = Modifier.weight(1f))
+                    }
+
+                    confirmAction(modifier = Modifier.weight(1f))
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun KieroDialogPreview() {
+    KieroTheme {
+        KieroDialog(
+            onDismiss = {},
+            title = "제목",
+            subDescription = "로그아웃 하시겠습니까?",
+
+            cancelAction = KieroCancelAction(
+                text = "취소",
+                onClick = {}
+            ),
+            confirmAction = KieroConfirmAction(
+                text = "확인",
+                onClick = {}
+            ),
+
+            content = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Image(
+                        painter = painterResource(R.drawable.img_kid_coin),
+                        contentDescription = null,
+                        modifier = Modifier.forcePixelToDp(painterResource(R.drawable.img_kid_coin))
+                    )
+
+                    Spacer(modifier = Modifier.width(10.dp))
+
+                    Text(
+                        text = "150 개",
+                        color = KieroTheme.colors.main,
+                        style = KieroTheme.typography.semiBold.title4,
+                    )
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/kiero/core/designsystem/component/dialog/action/DialogAction.kt
+++ b/app/src/main/java/com/kiero/core/designsystem/component/dialog/action/DialogAction.kt
@@ -1,0 +1,9 @@
+package com.kiero.core.designsystem.component.dialog.action
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+fun interface DialogAction {
+    @Composable
+    operator fun invoke(modifier: Modifier)
+}

--- a/app/src/main/java/com/kiero/core/designsystem/component/dialog/action/KieroCancelAction.kt
+++ b/app/src/main/java/com/kiero/core/designsystem/component/dialog/action/KieroCancelAction.kt
@@ -1,0 +1,47 @@
+package com.kiero.core.designsystem.component.dialog.action
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.kiero.core.designsystem.theme.KieroTheme
+
+class KieroCancelAction(
+    private val text: String = "취소",
+    private val onClick: () -> Unit
+) : DialogAction {
+    @Composable
+    override fun invoke(modifier: Modifier) {
+        // Todo : 공통(kiero) 버튼으로 수정하기
+        Button(
+            onClick = onClick,
+            modifier = modifier,
+            shape = RoundedCornerShape(8.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = KieroTheme.colors.gray800
+            )
+        ) {
+            Text(
+                text = text,
+                color = Color.White,
+                fontSize = 16.sp
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun KieroCancelActionPreview() {
+    KieroTheme {
+        KieroCancelAction(
+            onClick = {}
+        ).invoke(modifier = Modifier)
+    }
+}

--- a/app/src/main/java/com/kiero/core/designsystem/component/dialog/action/KieroConfirmAction.kt
+++ b/app/src/main/java/com/kiero/core/designsystem/component/dialog/action/KieroConfirmAction.kt
@@ -1,0 +1,49 @@
+package com.kiero.core.designsystem.component.dialog.action
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.kiero.core.designsystem.theme.KieroTheme
+
+class KieroConfirmAction(
+    private val text: String = "확인",
+    private val onClick: () -> Unit
+) : DialogAction {
+    @Composable
+    override fun invoke(modifier: Modifier) {
+        // Todo : 공통(kiero) 버튼으로 수정하기
+        Button(
+            onClick = onClick,
+            modifier = modifier,
+            shape = RoundedCornerShape(8.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = KieroTheme.colors.main
+            )
+        ) {
+            Text(
+                text = text,
+                color = Color.Black,
+                fontWeight = FontWeight.Bold,
+                fontSize = 16.sp
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun KieroConfirmActionPreview() {
+    KieroTheme {
+        KieroConfirmAction(
+            onClick = {}
+        ).invoke(modifier = Modifier)
+    }
+}


### PR DESCRIPTION
## ISSUE
- closed #15 

## ❗ WORK DESCRIPTION
- 공통 다이얼로그를 구현하였습니다
- px -> dp로 강제 변환하는 확장함수를 구현했습니다

## 📢 TO REVIEWERS
- Slot API 패턴과 액션 interface 패턴을 적용하여 버튼의 개수 여부 관련해서 판단할 필요없이 개발자 동료가 다이얼로그의 content를 그리는데만 집중할 수 있게 구현하였습니다
이제 버튼과 관련된 액션으로 어떻게 그리는지 보다는 무엇을 하는 지(가독성)에 집중할 수 있도록 하였습니다

- px -> dp 예를들어 png가 22px일때 22dp로 강제 변환하여 size를 반환하도록 하였습니다

## 📸 SCREENSHOT
<img width="206" height="461" alt="image" src="https://github.com/user-attachments/assets/7622f66c-6482-4796-a2c6-eb5d986d9a3a" />

<!-- video src="" witdh="300"/>-->
