### PR TITLE
[feat/#22]  오늘의 여정 뷰 컴포넌트 구현

### DIFF
--- a/app/src/main/java/com/kiero/core/designsystem/component/KieroToolTip.kt
+++ b/app/src/main/java/com/kiero/core/designsystem/component/KieroToolTip.kt
@@ -1,0 +1,74 @@
+package com.kiero.core.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.asComposePath
+import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.graphics.shapes.CornerRounding
+import androidx.graphics.shapes.RoundedPolygon
+import androidx.graphics.shapes.toPath
+import com.kiero.core.designsystem.theme.KieroTheme
+
+@Composable
+fun KieroToolTip(
+    message: String,
+    modifier: Modifier = Modifier,
+) {
+    val backgroundColor = KieroTheme.colors.gray900
+
+    Box(
+        modifier = modifier
+            .padding(bottom = 13.dp)
+            .drawWithCache {
+                val roundedPolygon = RoundedPolygon(
+                    numVertices = 3,
+                    radius = 12.dp.toPx(),
+                    centerX = size.width / 2,
+                    centerY = size.height,
+                    rounding = CornerRounding(radius = 2.dp.toPx())
+                )
+
+                val composePath = roundedPolygon.toPath().asComposePath()
+
+                onDrawBehind {
+                    val pivot = Offset(size.width / 2, size.height)
+
+                    rotate(degrees = 90f, pivot = pivot) {
+                        translate(left = 2.dp.toPx()) {
+                            drawPath(path = composePath, color = backgroundColor)
+                        }
+                    }
+                }
+            }
+            .background(color = backgroundColor, shape = RoundedCornerShape(15.dp))
+            .padding(horizontal = 20.dp, vertical = 12.5.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = message,
+            style = KieroTheme.typography.regular.body3,
+            color = KieroTheme.colors.gray300,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Preview(showBackground = false)
+@Composable
+private fun KieroToolTipPreview() {
+    KieroToolTip(
+        message = "이 텍스트는 말풍선에 들어가는 텍스트"
+    )
+}

--- a/app/src/main/java/com/kiero/presentation/kid/component/SpeechField.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/component/SpeechField.kt
@@ -25,7 +25,10 @@ fun SpeechField(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit
 ) {
-    Box(modifier = modifier.padding(top = 17.dp)) {
+    Box(
+        modifier = modifier
+            .padding(top = 17.dp)
+    ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -40,7 +43,7 @@ fun SpeechField(
         Text(
             text = name,
             modifier = Modifier
-                .offset(x = 18.dp, y = (-17).dp)
+                .offset(x = 18.dp, y = (-16).dp)
                 .background((KieroTheme.colors.main), shape = RoundedCornerShape(4.dp))
                 .padding(vertical = 2.dp, horizontal = 10.dp)
         )

--- a/app/src/main/java/com/kiero/presentation/kid/component/SpeechField.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/component/SpeechField.kt
@@ -1,0 +1,81 @@
+package com.kiero.presentation.kid.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.kiero.core.designsystem.theme.KieroTheme
+
+@Composable
+fun SpeechField(
+    name: String,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    Box(modifier = modifier.padding(top = 17.dp)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background((KieroTheme.colors.gray900), shape = RoundedCornerShape(15.dp))
+                .padding(vertical = 14.dp, horizontal = 12.dp),
+            horizontalAlignment = Alignment.Start,
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            content()
+        }
+
+        Text(
+            text = name,
+            modifier = Modifier
+                .offset(x = 18.dp, y = (-17).dp)
+                .background((KieroTheme.colors.main), shape = RoundedCornerShape(4.dp))
+                .padding(vertical = 2.dp, horizontal = 10.dp)
+        )
+    }
+}
+
+@Preview(showBackground = false)
+@Composable
+private fun SpeechFieldPreview() {
+    SpeechField(
+        name = "이름"
+    ) {
+        Text("첫번째 줄 입니다", color = KieroTheme.colors.gray300)
+        Text("두번째 줄 입니다", color = KieroTheme.colors.gray300)
+
+        Text(
+            text = buildAnnotatedString {
+                append("덕분에 ")
+                withStyle(style = SpanStyle(color = KieroTheme.colors.main)) {
+                    append("영웅의 불꽃")
+                }
+                append(" 이 커졌어!")
+            },
+            color = KieroTheme.colors.gray300
+        )
+
+        Text(
+            text = buildAnnotatedString {
+                append("선물로 금화 ")
+                withStyle(style = SpanStyle(color = KieroTheme.colors.main)) {
+                    append("10")
+                }
+                append(" 개를 줄게")
+            },
+            color = KieroTheme.colors.gray300
+        )
+    }
+}

--- a/app/src/main/java/com/kiero/presentation/kid/journey/component/ScheduleInfoItem.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/component/ScheduleInfoItem.kt
@@ -1,0 +1,73 @@
+package com.kiero.presentation.kid.journey.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.BaselineShift
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.kiero.core.designsystem.theme.KieroTheme
+import com.kiero.presentation.kid.journey.model.TodayScheduleModel
+import java.time.LocalTime
+
+@Composable
+fun ScheduleInfoItem(
+    item: TodayScheduleModel,
+    modifier: Modifier = Modifier
+) {
+    val timeAnnotatedString = buildAnnotatedString {
+        val amPmStyle = KieroTheme.typography.regular.body5.toSpanStyle().copy(
+            baselineShift = BaselineShift(0.05f)
+        )
+
+        withStyle(style = amPmStyle) { append(item.startTime.format(item.amPmFormatter)) }
+        append("  ${item.startTime.format(item.timeNumberFormatter)}  ~  ")
+
+
+        withStyle(style = amPmStyle) { append(item.endTime.format(item.amPmFormatter)) }
+        append("  ${item.endTime.format(item.timeNumberFormatter)}")
+    }
+
+    Row(
+        modifier = modifier
+            .background(color = KieroTheme.colors.gray900, shape = RoundedCornerShape(15.dp))
+            .padding(start = 20.dp, end = 20.dp, top = 14.dp, bottom = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = item.displayTitle,
+            style = KieroTheme.typography.regular.body3,
+            color = KieroTheme.colors.gray300,
+        )
+
+        Spacer(modifier = Modifier.width(40.dp))
+
+
+        Text(
+            text = timeAnnotatedString,
+            style = KieroTheme.typography.regular.body3,
+            color = KieroTheme.colors.main,
+        )
+    }
+}
+
+@Preview(showBackground = false)
+@Composable
+private fun ScheduleInfoItemPreview() {
+    ScheduleInfoItem(
+        item = TodayScheduleModel(
+            order = 8,
+            startTime = LocalTime.of(9, 0),
+            endTime = LocalTime.of(10, 0)
+        )
+    )
+}

--- a/app/src/main/java/com/kiero/presentation/kid/journey/component/ScheduleInfoItem.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/component/ScheduleInfoItem.kt
@@ -16,12 +16,12 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kiero.core.designsystem.theme.KieroTheme
-import com.kiero.presentation.kid.journey.model.TodayScheduleModel
+import com.kiero.presentation.kid.journey.model.JourneyScheduleModel
 import java.time.LocalTime
 
 @Composable
 fun ScheduleInfoItem(
-    item: TodayScheduleModel,
+    item: JourneyScheduleModel,
     modifier: Modifier = Modifier
 ) {
     val timeAnnotatedString = buildAnnotatedString {
@@ -64,8 +64,8 @@ fun ScheduleInfoItem(
 @Composable
 private fun ScheduleInfoItemPreview() {
     ScheduleInfoItem(
-        item = TodayScheduleModel(
-            order = 8,
+        item = JourneyScheduleModel(
+            order = 1,
             startTime = LocalTime.of(9, 0),
             endTime = LocalTime.of(10, 0)
         )

--- a/app/src/main/java/com/kiero/presentation/kid/journey/model/JourneyScheduleModel.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/model/JourneyScheduleModel.kt
@@ -4,7 +4,7 @@ import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
-data class TodayScheduleModel(
+data class JourneyScheduleModel(
     val order: Int,
     val startTime: LocalTime,
     val endTime: LocalTime

--- a/app/src/main/java/com/kiero/presentation/kid/journey/model/TodayScheduleModel.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/model/TodayScheduleModel.kt
@@ -1,0 +1,26 @@
+package com.kiero.presentation.kid.journey.model
+
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+data class TodayScheduleModel(
+    val order: Int,
+    val startTime: LocalTime,
+    val endTime: LocalTime
+) {
+    val amPmFormatter: DateTimeFormatter? = DateTimeFormatter.ofPattern("a", Locale.KOREAN)
+    val timeNumberFormatter: DateTimeFormatter? = DateTimeFormatter.ofPattern("hh : mm", Locale.KOREAN)
+
+    val orderText: String
+        get() = when (order) {
+            1 -> "첫 번째"
+            2 -> "두 번째"
+            3 -> "세 번째"
+            else -> "$order 번째"
+        }
+
+    val displayTitle: String
+        get() = "$orderText 여정 시간"
+}
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ navigation = "2.9.6"
 security = "1.1.0"
 androidxCoreSplash = "1.0.1"
 lifecycleRuntimeComposeAndroid = "2.10.0"
+graphicsShapes = "1.1.0"
 
 #Network
 okhttp = "5.3.2"
@@ -82,6 +83,7 @@ androidx-navigation = { group = "androidx.navigation", name = "navigation-compos
 androidx-security = { group = "androidx.security", name = "security-crypto-ktx", version.ref = "security" }
 androidx-lifecycle-runtime-compose-android = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose-android", version.ref = "lifecycleRuntimeComposeAndroid" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "androidxCoreSplash" }
+androidx-graphics-shapes = { group = "androidx.graphics", name = "graphics-shapes", version.ref = "graphicsShapes" }
 
 # Network
 okhttp-bom = { group = "com.squareup.okhttp3", name = "okhttp-bom", version.ref = "okhttp" }
@@ -137,7 +139,8 @@ androidx = [
     "androidx-security",
     "androidx-appcompat",
     "androidx-lifecycle-runtime-compose-android",
-    "androidx-core-splashscreen"
+    "androidx-core-splashscreen",
+    "androidx-graphics-shapes"
 ]
 
 test = [


### PR DESCRIPTION
## ISSUE
- closed #22

## ❗ WORK DESCRIPTION
오늘의 여정 뷰에 해당하는 컴포넌트를 구현하였습니다.
- 여정 시간 정보 아이템 구현 (ScheduleInfoItem)
- 여정 일정 데이터 모델 정의 (JourneyScheduleModel)
- 커스텀 말풍선 컴포넌트 구현 (KieroToolTip)
- 캐릭터의 멘트창 구현 (SpeechField)

## 📢 TO REVIEWERS
ScheduleInfoItem, JourneyScheduleModel
- 오전/오후와 hh : mm 형식을 분리하여 시간 정보 UI 요구사항을 반영하도록 하였습니다(글자 스타일 다름)
- Int 타입의 순서 데이터를 "첫 번째", "두 번째"와 같은 한국어 서수 표현으로 변경 로직을 구현하였습니다.

KieroToolTip
- graphics-shapes 라이브러리의 RoundedPolygon을 사용하여 하단 꼬리를 붙인 말풍선 컴포넌트를 구현하였습니다.

SpeechField
- 상단에 이름 라벨(name)이 포함된 대화창 형태의 필드입니다. 내부 content를 람다로 받아 다양한 텍스트나 레이아웃을 유연하게 배치할 수 있도록 설계했습니다.

## 📸 SCREENSHOT
<img src="" width="300" />
<img width="300" src="https://github.com/user-attachments/assets/681c2310-f46f-4c07-a4d5-8f557f71f46e" />
<img width="300" src="https://github.com/user-attachments/assets/c75d6e0c-071f-4033-a33c-53fb321021b8" />
<img width="300" src="https://github.com/user-attachments/assets/ae4d9791-d308-4ec4-9c99-58a04de47110" />
