### PR TITLE
[feat/#50] 일정 조회 및 추가 API 연동

### DIFF
--- a/app/src/main/java/com/kiero/core/common/util/formatTime.kt
+++ b/app/src/main/java/com/kiero/core/common/util/formatTime.kt
@@ -1,7 +1,29 @@
 package com.kiero.core.common.util
 
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
+
+object PlanFormatters{
+    val SERVER_TIME_FMT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss")
+    val UI_TIME_FMT: DateTimeFormatter = DateTimeFormatter.ofPattern("hh:mm a", Locale.US)
+    val DAY_OF_WEEK_FMT: DateTimeFormatter = DateTimeFormatter.ofPattern("d(E)", Locale.KOREAN)
+    val DATE_RANGE_FMT: DateTimeFormatter = DateTimeFormatter.ofPattern("M.d(E)", Locale.KOREAN)
+
+
+    fun formatDuration(totalSeconds: Int, includeHours: Boolean = false): String {
+        val hours = totalSeconds / 3600
+        val minutes = (totalSeconds % 3600) / 60
+        val seconds = totalSeconds % 60
+
+        return if (includeHours || hours > 0) {
+            String.format(Locale.getDefault(), "%02d:%02d:%02d", hours, minutes, seconds)
+        } else {
+            String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds)
+        }
+    }
+    // TODO : 필요시 Util에 넣어서 사용하기
+}
 fun formatTime(totalSeconds: Int): String {
     val minutes = totalSeconds / 60
     val seconds = totalSeconds % 60

--- a/app/src/main/java/com/kiero/data/mission/di/MissionServiceModule.kt
+++ b/app/src/main/java/com/kiero/data/mission/di/MissionServiceModule.kt
@@ -8,6 +8,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
+import retrofit2.create
 import javax.inject.Singleton
 
 @Module
@@ -26,7 +27,6 @@ object MissionServiceModule {
     fun provideParentMissionAddService(
         @AuthNetwork retrofit: Retrofit,
     ): ParentMissionService {
-        return retrofit.create(ParentMissionService::class.java)
+        return retrofit.create()
     }
-
 }

--- a/app/src/main/java/com/kiero/data/parent/di/ParentDataSourceModule.kt
+++ b/app/src/main/java/com/kiero/data/parent/di/ParentDataSourceModule.kt
@@ -1,0 +1,19 @@
+package com.kiero.data.parent.di
+
+import com.kiero.data.parent.plan.remote.datasource.PlanDataSource
+import com.kiero.data.parent.plan.remote.datasourceimpl.PlanDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ParentDataSourceModule {
+    @Binds
+    @Singleton
+    abstract fun bindPlanDataSource(
+        planDataSourceImpl: PlanDataSourceImpl
+    ): PlanDataSource
+}

--- a/app/src/main/java/com/kiero/data/parent/di/ParentRepositoryModule.kt
+++ b/app/src/main/java/com/kiero/data/parent/di/ParentRepositoryModule.kt
@@ -1,0 +1,19 @@
+package com.kiero.data.parent.di
+
+import com.kiero.data.parent.plan.repository.PlanRepository
+import com.kiero.data.parent.plan.repositoryimpl.PlanRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface ParentRepositoryModule {
+    @Binds
+    @Singleton
+    fun bindPlanRepository(
+        planRepositoryImpl: PlanRepositoryImpl,
+    ): PlanRepository
+}

--- a/app/src/main/java/com/kiero/data/parent/di/ParentServiceModule.kt
+++ b/app/src/main/java/com/kiero/data/parent/di/ParentServiceModule.kt
@@ -1,0 +1,21 @@
+package com.kiero.data.parent.di
+
+import com.kiero.core.network.di.AuthNetwork
+import com.kiero.data.parent.plan.remote.api.PlanService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.create
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ParentServiceModule {
+    @Provides
+    @Singleton
+    fun providePlanService(
+        @AuthNetwork retrofit: Retrofit,
+    ): PlanService = retrofit.create()
+}

--- a/app/src/main/java/com/kiero/data/parent/plan/model/PlanContentModel.kt
+++ b/app/src/main/java/com/kiero/data/parent/plan/model/PlanContentModel.kt
@@ -1,0 +1,62 @@
+package com.kiero.data.parent.plan.model
+
+import NormalScheduleDto
+import PlanAllResponseDto
+import RecurringScheduleDto
+import com.kiero.data.parent.plan.remote.dto.response.PlanColorResponseDto
+
+data class PlanColorModel(
+    val scheduleColor : String,
+    val colorColor : String,
+)
+
+
+fun PlanColorResponseDto.toModel() = PlanColorModel(
+    scheduleColor = this.scheduleColor,
+    colorColor = this.colorCode,
+)
+
+data class PlanAllModel(
+    val isFireLit: Boolean,
+    val recurringSchedules: List<RecurringScheduleModel>,
+    val normalSchedules: List<NormalScheduleModel>
+)
+
+data class RecurringScheduleModel(
+    val startTime: String,
+    val endTime: String,
+    val name: String,
+    val colorCode: String,
+    val dayOfWeek: String
+)
+
+data class NormalScheduleModel(
+    val startTime: String,
+    val endTime: String,
+    val name: String,
+    val colorCode: String,
+    val date: String
+)
+
+
+fun PlanAllResponseDto.toModel(): PlanAllModel = PlanAllModel(
+    isFireLit = this.isFireLit,
+    recurringSchedules = this.recurringSchedules.map { it.toModel() },
+    normalSchedules = this.normalSchedules.map { it.toModel() }
+)
+
+fun RecurringScheduleDto.toModel(): RecurringScheduleModel = RecurringScheduleModel(
+    startTime = this.startTime,
+    endTime = this.endTime,
+    name = this.name,
+    colorCode = this.colorCode,
+    dayOfWeek = this.dayOfWeek
+)
+
+fun NormalScheduleDto.toModel(): NormalScheduleModel = NormalScheduleModel(
+    startTime = this.startTime,
+    endTime = this.endTime,
+    name = this.name,
+    colorCode = this.colorCode,
+    date = this.date
+)

--- a/app/src/main/java/com/kiero/data/parent/plan/model/PlanContentModel.kt
+++ b/app/src/main/java/com/kiero/data/parent/plan/model/PlanContentModel.kt
@@ -7,13 +7,13 @@ import com.kiero.data.parent.plan.remote.dto.response.PlanColorResponseDto
 
 data class PlanColorModel(
     val scheduleColor : String,
-    val colorColor : String,
+    val colorCode : String,
 )
 
 
 fun PlanColorResponseDto.toModel() = PlanColorModel(
     scheduleColor = this.scheduleColor,
-    colorColor = this.colorCode,
+    colorCode = this.colorCode,
 )
 
 data class PlanAllModel(

--- a/app/src/main/java/com/kiero/data/parent/plan/remote/api/PlanService.kt
+++ b/app/src/main/java/com/kiero/data/parent/plan/remote/api/PlanService.kt
@@ -1,0 +1,31 @@
+package com.kiero.data.parent.plan.remote.api
+
+import PlanAllResponseDto
+import com.kiero.core.network.model.BaseResponse
+import com.kiero.data.parent.plan.remote.dto.request.PlanAddRequestDto
+import com.kiero.data.parent.plan.remote.dto.response.PlanColorResponseDto
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface PlanService {
+    @GET("api/v1/schedules/{childId}/default")
+    suspend fun getPlanColor(
+        @Path("childId") childId: Long,
+    ): BaseResponse<PlanColorResponseDto>
+
+    @POST("api/v1/schedules/{childId}")
+    suspend fun postPlan(
+        @Path("childId") childId: Long,
+        @Body planAddRequestDto: PlanAddRequestDto,
+    ): BaseResponse<Unit>
+
+    @GET("api/v1/schedules/{childId}")
+    suspend fun getPlanAll(
+        @Path("childId") childId: Long,
+        @Query("startDate") startDate: String,
+        @Query("endDate") endDate: String,
+    ): BaseResponse<PlanAllResponseDto>
+}

--- a/app/src/main/java/com/kiero/data/parent/plan/remote/datasource/PlanDataSource.kt
+++ b/app/src/main/java/com/kiero/data/parent/plan/remote/datasource/PlanDataSource.kt
@@ -1,0 +1,17 @@
+package com.kiero.data.parent.plan.remote.datasource
+
+import PlanAllResponseDto
+import com.kiero.core.network.model.BaseResponse
+import com.kiero.data.parent.plan.remote.dto.request.PlanAddRequestDto
+import com.kiero.data.parent.plan.remote.dto.response.PlanColorResponseDto
+
+interface PlanDataSource {
+    suspend fun getPlanColor(childId: Long): BaseResponse<PlanColorResponseDto>
+    suspend fun postPlan(childId: Long, requestDto: PlanAddRequestDto): BaseResponse<Unit>
+
+    suspend fun getPlanAll(
+        childId: Long,
+        startDate: String,
+        endDate: String,
+    ): BaseResponse<PlanAllResponseDto>
+}

--- a/app/src/main/java/com/kiero/data/parent/plan/remote/datasourceimpl/PlanDataSourceImpl.kt
+++ b/app/src/main/java/com/kiero/data/parent/plan/remote/datasourceimpl/PlanDataSourceImpl.kt
@@ -1,0 +1,22 @@
+package com.kiero.data.parent.plan.remote.datasourceimpl
+
+import PlanAllResponseDto
+import com.kiero.core.network.model.BaseResponse
+import com.kiero.data.parent.plan.remote.api.PlanService
+import com.kiero.data.parent.plan.remote.datasource.PlanDataSource
+import com.kiero.data.parent.plan.remote.dto.request.PlanAddRequestDto
+import com.kiero.data.parent.plan.remote.dto.response.PlanColorResponseDto
+import javax.inject.Inject
+
+class PlanDataSourceImpl @Inject constructor(
+    private val planService: PlanService,
+) : PlanDataSource {
+    override suspend fun getPlanColor(childId: Long): BaseResponse<PlanColorResponseDto> =
+        planService.getPlanColor(childId)
+
+    override suspend fun postPlan(childId: Long, requestDto: PlanAddRequestDto): BaseResponse<Unit> =
+        planService.postPlan(childId, requestDto)
+
+    override suspend fun getPlanAll(childId: Long, startDate: String, endDate: String): BaseResponse<PlanAllResponseDto> =
+        planService.getPlanAll(childId, startDate, endDate)
+}

--- a/app/src/main/java/com/kiero/data/parent/plan/remote/dto/request/PlanAddRequestDto.kt
+++ b/app/src/main/java/com/kiero/data/parent/plan/remote/dto/request/PlanAddRequestDto.kt
@@ -1,0 +1,22 @@
+package com.kiero.data.parent.plan.remote.dto.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PlanAddRequestDto(
+    @SerialName("name")
+    val name: String,
+    @SerialName("isRecurring")
+    val isRecurring: Boolean,
+    @SerialName("startTime")
+    val startTime: String,
+    @SerialName("endTime")
+    val endTime: String,
+    @SerialName("scheduleColor")
+    val scheduleColor: String,
+    @SerialName("dayOfWeek")
+    val dayOfWeek: String?,
+    @SerialName("date")
+    val date: String?,
+)

--- a/app/src/main/java/com/kiero/data/parent/plan/remote/dto/response/PlanAllResponseDto.kt
+++ b/app/src/main/java/com/kiero/data/parent/plan/remote/dto/response/PlanAllResponseDto.kt
@@ -1,0 +1,40 @@
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PlanAllResponseDto(
+    @SerialName("isFireLit")
+    val isFireLit: Boolean,
+    @SerialName("recurringSchedules")
+    val recurringSchedules: List<RecurringScheduleDto>,
+    @SerialName("normalSchedules")
+    val normalSchedules: List<NormalScheduleDto>
+)
+
+@Serializable
+data class RecurringScheduleDto(
+    @SerialName("startTime")
+    val startTime: String,
+    @SerialName("endTime")
+    val endTime: String,
+    @SerialName("name")
+    val name: String,
+    @SerialName("colorCode")
+    val colorCode: String,
+    @SerialName("dayOfWeek")
+    val dayOfWeek: String
+)
+
+@Serializable
+data class NormalScheduleDto(
+    @SerialName("startTime")
+    val startTime: String,
+    @SerialName("endTime")
+    val endTime: String,
+    @SerialName("name")
+    val name: String,
+    @SerialName("colorCode")
+    val colorCode: String,
+    @SerialName("date")
+    val date: String
+)

--- a/app/src/main/java/com/kiero/data/parent/plan/remote/dto/response/PlanColorResponseDto.kt
+++ b/app/src/main/java/com/kiero/data/parent/plan/remote/dto/response/PlanColorResponseDto.kt
@@ -1,0 +1,12 @@
+package com.kiero.data.parent.plan.remote.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PlanColorResponseDto(
+    @SerialName("scheduleColor")
+    val scheduleColor: String,
+    @SerialName("colorCode")
+    val colorCode: String,
+)

--- a/app/src/main/java/com/kiero/data/parent/plan/repository/PlanRepository.kt
+++ b/app/src/main/java/com/kiero/data/parent/plan/repository/PlanRepository.kt
@@ -1,0 +1,25 @@
+package com.kiero.data.parent.plan.repository
+
+import com.kiero.data.parent.plan.model.PlanAllModel
+import com.kiero.data.parent.plan.model.PlanColorModel
+
+interface PlanRepository {
+    suspend fun getPlanColor(childId: Long): Result<PlanColorModel>
+
+    suspend fun postPlan(
+        childId: Long,
+        name: String,
+        isRecurring: Boolean,
+        startTime: String,
+        endTime: String,
+        scheduleColor: String,
+        dayOfWeek: String?,
+        date: String?,
+    ): Result<Unit>
+
+    suspend fun getPlanAll(
+        childId: Long,
+        startDate: String,
+        endDate: String,
+    ): Result<PlanAllModel>
+}

--- a/app/src/main/java/com/kiero/data/parent/plan/repositoryimpl/PlanRepositoryImpl.kt
+++ b/app/src/main/java/com/kiero/data/parent/plan/repositoryimpl/PlanRepositoryImpl.kt
@@ -36,11 +36,7 @@ class PlanRepositoryImpl @Inject constructor(
             dayOfWeek = dayOfWeek,
             date = date
         )
-        val response = dataSource.postPlan(childId, requestDto)
-
-        if (response.status !in 200..299) {
-            throw Exception(response.message ?: "일정 추가에 실패했습니다")
-        }
+        dataSource.postPlan(childId, requestDto)
         Unit
     }
 

--- a/app/src/main/java/com/kiero/data/parent/plan/repositoryimpl/PlanRepositoryImpl.kt
+++ b/app/src/main/java/com/kiero/data/parent/plan/repositoryimpl/PlanRepositoryImpl.kt
@@ -1,0 +1,58 @@
+package com.kiero.data.parent.plan.repositoryimpl
+
+import com.kiero.core.common.util.suspendRunCatching
+import com.kiero.data.parent.plan.model.PlanAllModel
+import com.kiero.data.parent.plan.model.PlanColorModel
+import com.kiero.data.parent.plan.model.toModel
+import com.kiero.data.parent.plan.remote.datasource.PlanDataSource
+import com.kiero.data.parent.plan.remote.dto.request.PlanAddRequestDto
+import com.kiero.data.parent.plan.repository.PlanRepository
+import javax.inject.Inject
+
+class PlanRepositoryImpl @Inject constructor(
+    private val dataSource: PlanDataSource,
+) : PlanRepository {
+    override suspend fun getPlanColor(childId: Long): Result<PlanColorModel> =
+        suspendRunCatching {
+            dataSource.getPlanColor(childId).data!!.toModel()
+        }
+
+    override suspend fun postPlan(
+        childId: Long,
+        name: String,
+        isRecurring: Boolean,
+        startTime: String,
+        endTime: String,
+        scheduleColor: String,
+        dayOfWeek: String?,
+        date: String?,
+    ): Result<Unit> = suspendRunCatching {
+        val requestDto = PlanAddRequestDto(
+            name = name,
+            isRecurring = isRecurring,
+            startTime = startTime,
+            endTime = endTime,
+            scheduleColor = scheduleColor,
+            dayOfWeek = dayOfWeek,
+            date = date
+        )
+        val response = dataSource.postPlan(childId, requestDto)
+
+        if (response.status !in 200..299) {
+            throw Exception(response.message ?: "일정 추가에 실패했습니다")
+        }
+        Unit
+    }
+
+    override suspend fun getPlanAll(
+        childId: Long,
+        startDate: String,
+        endDate: String,
+    ): Result<PlanAllModel> = suspendRunCatching {
+        dataSource.getPlanAll(
+            childId = childId,
+            startDate = startDate,
+            endDate = endDate
+        ).data!!.toModel()
+    }
+}

--- a/app/src/main/java/com/kiero/data/parent/repositoryimpl/ParentMissionAddRepositoryImpl.kt
+++ b/app/src/main/java/com/kiero/data/parent/repositoryimpl/ParentMissionAddRepositoryImpl.kt
@@ -23,9 +23,13 @@ class ParentMissionAddRepositoryImpl @Inject constructor(
             dueAt = dueAt
         )
 
-        dataSource.postParentMission(
+        val response = dataSource.postParentMission(
             childId = childId,
             requestDto = requestDto
-        ).data!!.toModel()
+        )
+
+        val responseData = response.data ?: throw Exception(response.message)
+
+        responseData.toModel()
     }
 }

--- a/app/src/main/java/com/kiero/presentation/kid/wish/viewmodel/KidWishViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/wish/viewmodel/KidWishViewModel.kt
@@ -6,7 +6,6 @@ import com.kiero.core.common.extension.updateSuccess
 import com.kiero.core.model.UiState
 import com.kiero.data.kid.coin.repository.CoinRepository
 import com.kiero.data.kid.wish.repository.WishRepository
-import com.kiero.data.mission.repository.MissionRepository
 import com.kiero.presentation.kid.wish.model.toState
 import com.kiero.presentation.kid.wish.model.toUiModel
 import com.kiero.presentation.kid.wish.state.KidWishSideEffect
@@ -27,8 +26,7 @@ import javax.inject.Inject
 @HiltViewModel
 class KidWishViewModel @Inject constructor(
     private val repository: CoinRepository,
-    private val missionRepository: MissionRepository,
-    private val wishRepository: WishRepository
+    private val wishRepository: WishRepository,
 ) : ViewModel() {
     private val _state = MutableStateFlow<UiState<KidWishState>>(UiState.Loading)
     val state: StateFlow<UiState<KidWishState>> = combine(
@@ -93,7 +91,7 @@ class KidWishViewModel @Inject constructor(
     }
 
     fun prayWish(
-        couponId: Long
+        couponId: Long,
     ) {
         viewModelScope.launch {
             wishRepository.patchCoupon(couponId)

--- a/app/src/main/java/com/kiero/presentation/parent/component/ParentUserSection.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/component/ParentUserSection.kt
@@ -6,17 +6,22 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 import com.kiero.R
 import com.kiero.core.common.extension.noRippleClickable
 import com.kiero.core.designsystem.theme.KieroTheme
@@ -24,6 +29,7 @@ import com.kiero.core.designsystem.theme.KieroTheme
 @Composable
 fun ParentUserSection(
     userName: String,
+    profileImage: String,
     onUserNameClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -43,13 +49,26 @@ fun ParentUserSection(
 
         Spacer(modifier = Modifier.width(4.dp))
 
-        Icon(
-            imageVector = ImageVector.vectorResource(id = R.drawable.ic_parent_profile),
-            contentDescription = null,
-            tint = Color.Unspecified,
-            modifier = Modifier
-                .noRippleClickable(onClick = onUserNameClick)
-        )
+        if (profileImage.isEmpty()) {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_parent_profile),
+                contentDescription = null,
+                tint = Color.Unspecified,
+                modifier = Modifier.noRippleClickable(onClick = onUserNameClick)
+            )
+        } else {
+            Spacer(modifier = Modifier.width(5.dp))
+
+            AsyncImage(
+                model = profileImage,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(30.dp)
+                    .clip(CircleShape)
+                    .noRippleClickable(onClick = onUserNameClick)
+            )
+        }
     }
 }
 
@@ -59,6 +78,7 @@ private fun ParentUserSectionPreview() {
     KieroTheme {
         ParentUserSection(
             userName = "근영맘",
+            profileImage = "",
             onUserNameClick = {}
         )
     }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/ParentScheduleScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/ParentScheduleScreen.kt
@@ -20,9 +20,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kiero.core.common.extension.statusBarColor
 import com.kiero.core.designsystem.theme.Gray900
 import com.kiero.core.designsystem.theme.KieroTheme
+import com.kiero.core.model.UiState
 import com.kiero.presentation.parent.component.MissionTabFab
 import com.kiero.presentation.parent.component.ParentTabRow
 import com.kiero.presentation.parent.component.ParentUserSection
@@ -30,7 +33,9 @@ import com.kiero.presentation.parent.component.PlanTabFab
 import com.kiero.presentation.parent.schedule.mission.ParentMissionRoute
 import com.kiero.presentation.parent.schedule.model.TabItem
 import com.kiero.presentation.parent.schedule.plan.ParentPlanScreen
-import com.kiero.presentation.parent.schedule.plan.model.ScheduleData
+import com.kiero.presentation.parent.schedule.plan.state.ParentScheduleState
+import com.kiero.presentation.parent.schedule.viewmodel.ParentScheduleViewModel
+import com.kiero.presentation.signup.parent.state.ParentSignUpState
 
 @Composable
 fun ParentScheduleRoute(
@@ -38,28 +43,62 @@ fun ParentScheduleRoute(
     navigateUp: () -> Unit,
     navigateToScheduleAdd: () -> Unit,
     navigateToMissionAdd: () -> Unit,
+    viewModel: ParentScheduleViewModel = hiltViewModel(),
 ) {
+
+    val uiState by viewModel.state.collectAsStateWithLifecycle()
+    val authState by viewModel.authstate.collectAsStateWithLifecycle()
+
     var selectedTabIndex by remember { mutableIntStateOf(0) }
 
-    ParentScheduleScreen(
-        paddingValues = paddingValues,
-        navigateUp = navigateUp,
-        navigateToScheduleAdd = navigateToScheduleAdd,
-        navigateToMissionAdd = navigateToMissionAdd,
-        selectedTabIndex = selectedTabIndex,
-        onTabSelected = { selectedTabIndex = it }
-    )
+    when (val state = uiState) {
+        is UiState.Loading -> {
+
+        }
+
+        is UiState.Success -> {
+            ParentScheduleScreen(
+                paddingValues = paddingValues,
+                state = authState,
+                scheduleState = state.data,
+                selectedTabIndex = selectedTabIndex,
+                onTabSelected = { selectedTabIndex = it },
+                onDateChange = viewModel::onDateChange,
+                navigateToScheduleAdd = navigateToScheduleAdd,
+                navigateToMissionAdd = navigateToMissionAdd
+            )
+        }
+
+        is UiState.Failure -> {
+            // 에러 시 스낵바나 재시도 버튼 표시
+        }
+
+        is UiState.Empty -> {
+            ParentScheduleScreen(
+                paddingValues = paddingValues,
+                state = authState,
+                scheduleState = ParentScheduleState(),
+                selectedTabIndex = selectedTabIndex,
+                onTabSelected = { selectedTabIndex = it },
+                onDateChange = viewModel::onDateChange,
+                navigateToScheduleAdd = navigateToScheduleAdd,
+                navigateToMissionAdd = navigateToMissionAdd
+            )
+        }
+    }
 }
 
 @Composable
 private fun ParentScheduleScreen(
     paddingValues: PaddingValues,
-    navigateUp: () -> Unit,
+    state: ParentSignUpState,
+    scheduleState: ParentScheduleState,
+    selectedTabIndex: Int,
+    modifier: Modifier = Modifier,
+    onTabSelected: (Int) -> Unit,
+    onDateChange: (Boolean) -> Unit,
     navigateToScheduleAdd: () -> Unit,
     navigateToMissionAdd: () -> Unit,
-    selectedTabIndex: Int,
-    onTabSelected: (Int) -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     val tabs = remember { TabItem.entries.map { it.title } }
     var isMissionFabExpanded by remember { mutableStateOf(false) }
@@ -81,7 +120,8 @@ private fun ParentScheduleScreen(
                 .padding(paddingValues)
         ) {
             ParentUserSection(
-                userName = "근영맘",
+                userName = state.parentInfo.parentName,
+                profileImage = state.parentInfo.parentProfileImage,
                 onUserNameClick = {},
                 modifier = Modifier
                     .background(color = KieroTheme.colors.gray900)
@@ -94,7 +134,11 @@ private fun ParentScheduleScreen(
             )
 
             when (selectedTabIndex) {
-                0 -> ParentPlanScreen(events = ScheduleData.fakeScheduleEvents)
+                0 -> ParentPlanScreen(
+                    state = scheduleState,
+                    onDateChange = onDateChange
+                )
+
                 1 -> ParentMissionRoute(paddingValues)
             }
         }
@@ -124,7 +168,7 @@ private fun ParentScheduleScreen(
             1 -> MissionTabFab(
                 isExpanded = isMissionFabExpanded,
                 onExpandedChange = { isMissionFabExpanded = it },
-                onMissionAdd =  navigateToMissionAdd,
+                onMissionAdd = navigateToMissionAdd,
                 onMissionRecommend = { /* 규현이 화면 */ },
                 modifier = Modifier
                     .align(Alignment.BottomEnd)
@@ -138,13 +182,11 @@ private fun ParentScheduleScreen(
 @Preview
 private fun ParentScheduleScreenPreview() {
     KieroTheme {
-        ParentScheduleScreen(
+        ParentScheduleRoute(
             paddingValues = PaddingValues(),
             navigateUp = {},
             navigateToScheduleAdd = {},
-            navigateToMissionAdd = {},
-            selectedTabIndex = 0,
-            onTabSelected = {}
+            navigateToMissionAdd = {}
         )
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/ParentAddMissionScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/ParentAddMissionScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -19,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kiero.R
+import com.kiero.core.common.extension.collectSideEffect
 import com.kiero.core.designsystem.component.KieroTopbar
 import com.kiero.core.designsystem.theme.KieroTheme
 import com.kiero.core.model.UiState
@@ -42,6 +44,7 @@ fun ParentAddMissionRoute(
     val showBottomSheet by viewModel.showBottomSheet.collectAsStateWithLifecycle()
     val selectedDate by viewModel.selectedDate.collectAsStateWithLifecycle()
 
+    val dateText = viewModel.displayDate
     val globalTrigger = LocalGlobalUiEventTrigger.current
 
     // TODO : Test 용 고정값, 받아온 childId를 사용해야 됨.
@@ -50,16 +53,14 @@ fun ParentAddMissionRoute(
         viewModel.setChildId(1L)
     }
 
-    LaunchedEffect(Unit) {
-        viewModel.sideEffect.collect { effect ->
-            when (effect) {
-                is ParentAddMissionSideEffect.ShowSnackbar -> globalTrigger.showSnackbar(
-                    SnackbarState(message = effect.message)
-                )
+    viewModel.sideEffect.collectSideEffect { effect ->
+        when (effect) {
+            is ParentAddMissionSideEffect.ShowSnackbar -> globalTrigger.showSnackbar(
+                SnackbarState(message = effect.message)
+            )
 
-                is ParentAddMissionSideEffect.NavigateToMissionList -> {
-                    navigateUp()
-                }
+            is ParentAddMissionSideEffect.NavigateToMissionList -> {
+                navigateUp()
             }
         }
     }
@@ -80,18 +81,11 @@ fun ParentAddMissionRoute(
                 navigateUp = navigateUp,
                 viewModel = viewModel,
                 showBottomSheet = showBottomSheet,
-                selectedDate = selectedDate,
+                selectedDate = dateText,
             )
         }
     }
 
-    ParentAddMissionScreen(
-        paddingValues = paddingValues,
-        navigateUp = navigateUp,
-        viewModel = viewModel,
-        showBottomSheet = showBottomSheet,
-        selectedDate = selectedDate,
-    )
 }
 
 @Composable
@@ -106,7 +100,8 @@ fun ParentAddMissionScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(color = KieroTheme.colors.black),
+            .background(color = KieroTheme.colors.black)
+            .padding(paddingValues),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(15.dp)
     ) {

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/component/datepicker/component/CalendarBottomSheet.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/component/datepicker/component/CalendarBottomSheet.kt
@@ -1,6 +1,8 @@
 package com.kiero.presentation.parent.schedule.mission.component.datepicker.component
 
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -12,6 +14,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kiero.R
@@ -20,16 +23,15 @@ import com.kiero.presentation.parent.schedule.mission.component.datepicker.model
 import com.kiero.presentation.parent.schedule.plan.component.picker.PickerTopbar
 import java.time.LocalDate
 import java.time.YearMonth
-import java.time.format.DateTimeFormatter
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CalendarBottomSheet(
     modifier: Modifier = Modifier,
     onDismissRequest: () -> Unit,
-    onDateSelected: (String) -> Unit,
+    onDateSelected: (LocalDate) -> Unit,
 ) {
-    val sheetState = rememberModalBottomSheetState()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var yearMonth by remember { mutableStateOf(YearMonth.now()) }
     var selectedDate by remember { mutableStateOf<LocalDate?>(LocalDate.now()) }
     val today = LocalDate.now()
@@ -39,12 +41,17 @@ fun CalendarBottomSheet(
         sheetState = sheetState,
         containerColor = KieroTheme.colors.gray900,
         dragHandle = null,
+        modifier = modifier
+            .pointerInput(Unit) {
+                detectTapGestures {
+                }
+            }
     ) {
         Column(
-            modifier = modifier
+            modifier = Modifier
                 .fillMaxWidth()
+                .fillMaxHeight(0.5f)
                 .padding(vertical = 20.dp, horizontal = 30.dp)
-                .padding(bottom = 32.dp)
         ) {
             PickerTopbar(
                 title = "마감일",
@@ -53,8 +60,7 @@ fun CalendarBottomSheet(
                 rightIconRes = R.drawable.ic_check,
                 rightIconClick = {
                     selectedDate?.let { date ->
-                        val formattedDate = date.format(DateTimeFormatter.ISO_LOCAL_DATE)
-                        onDateSelected(formattedDate)
+                        onDateSelected(date)
                     }
                 }
             )

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/viewmodel/ParentAddMissionViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/viewmodel/ParentAddMissionViewModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.kiero.core.common.extension.formatWithDayOfWeek
 import com.kiero.data.parent.repository.ParentMissionAddRepository
 import com.kiero.presentation.parent.schedule.mission.component.model.MissionAwardDefaults
 import com.kiero.presentation.parent.schedule.mission.component.model.ParentMissionAddValid
@@ -18,6 +19,8 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 @HiltViewModel
@@ -40,10 +43,18 @@ class ParentAddMissionViewModel @Inject constructor(
     private val _currentAwardValue = MutableStateFlow(MissionAwardDefaults.DEFAULT_AWARD)
     val currentAwardValue = _currentAwardValue.asStateFlow()
 
-    private val _selectedDate = MutableStateFlow<String?>(null)
+    private val _selectedDate = MutableStateFlow<String?>(
+        LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
+    )
     val selectedDate = _selectedDate.asStateFlow()
 
+    val displayDate: String
+        get() = _selectedDate.value?.formatWithDayOfWeek ?: "마감일을 선택해주세요"
+
     init {
+        _state.update {
+            it.copy(selectedDate = _selectedDate.value)
+        }
         observeAwardTextFieldChanges()
         observeCurrentAwardValueChanges()
         observeMissionNameChanges()
@@ -119,13 +130,21 @@ class ParentAddMissionViewModel @Inject constructor(
         _state.update { it.copy(childId = childId) }
     }
 
+    fun onDateSelected(date: LocalDate) {
+        val formattedDate = date.format(DateTimeFormatter.ISO_LOCAL_DATE)
+        _selectedDate.value = formattedDate
+        onDismissBottomSheet()
+    }
+
+
     fun createMission() {
         val currentState = _state.value
+        val awardValue = _currentAwardValue.value
 
         val validationError = when {
             currentState.missionName.isBlank() -> ParentMissionAddValid.MISSION
-            _currentAwardValue.value <= 0 -> ParentMissionAddValid.AWARD
-            _currentAwardValue.value > 500 -> ParentMissionAddValid.MAX
+            awardValue <= 0 -> ParentMissionAddValid.AWARD
+            awardValue > 500 -> ParentMissionAddValid.MAX
             else -> null
         }
 
@@ -137,23 +156,26 @@ class ParentAddMissionViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
+            val childId = currentState.childId ?: 1L
+            val name = currentState.missionName
+            val reward = currentState.reward
+            val dueAt = currentState.selectedDate ?: LocalDate.now().toString() // 만약의 null 대비
+
             _state.update { it.copy(isLoading = true) }
 
             repository.postParentMission(
-                childId = currentState.childId!!,
-                name = currentState.missionName,
-                reward = currentState.reward,
-                dueAt = currentState.selectedDate!!
+                childId = childId,
+                name = name,
+                reward = reward,
+                dueAt = dueAt
             ).onSuccess { mission ->
                 _state.update { it.copy(isLoading = false) }
-                _sideEffect.emit(ParentAddMissionSideEffect.ShowSnackbar(message = "미션이 등록되었습니다."))
+                _sideEffect.emit(ParentAddMissionSideEffect.ShowSnackbar("미션이 등록되었습니다."))
                 _sideEffect.emit(ParentAddMissionSideEffect.NavigateToMissionList(mission))
             }.onFailure { error ->
                 _state.update { it.copy(isLoading = false) }
                 _sideEffect.emit(
-                    ParentAddMissionSideEffect.ShowSnackbar(
-                        error.message ?: "미션 생성에 실패했습니다."
-                    )
+                    ParentAddMissionSideEffect.ShowSnackbar(error.message ?: "미션 생성에 실패했습니다.")
                 )
             }
         }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/model/ScheduleTimeUtil.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/model/ScheduleTimeUtil.kt
@@ -1,5 +1,8 @@
 package com.kiero.presentation.parent.schedule.model
 
+import androidx.compose.ui.graphics.Color
+import androidx.core.graphics.toColorInt
+
 fun ScheduleEvent.toScheduleBlocks(dayIndex: Int): List<ScheduleBlock> {
     val (startHour, startMinute) = parseTime(startTime)
     val (endHour, endMinute) = parseTime(endTime)
@@ -8,13 +11,21 @@ fun ScheduleEvent.toScheduleBlocks(dayIndex: Int): List<ScheduleBlock> {
     val endSlot = ((endHour - 8) * 2) + (endMinute / 30)
     val totalSlots = endSlot - startSlot
 
-    val color = when (scheduleColor) {
-        "SCHEDULE1" -> ScheduleColorType.SCHEDULE1.color
-        "SCHEDULE2" -> ScheduleColorType.SCHEDULE2.color
-        "SCHEDULE3" -> ScheduleColorType.SCHEDULE3.color
-        "SCHEDULE4" -> ScheduleColorType.SCHEDULE4.color
-        "SCHEDULE5" -> ScheduleColorType.SCHEDULE5.color
-        else -> ScheduleColorType.SCHEDULE1.color
+    val color = try {
+        if (scheduleColor.startsWith("#")) {
+            Color(scheduleColor.toColorInt())
+        } else {
+            when (scheduleColor) {
+                "SCHEDULE1" -> ScheduleColorType.SCHEDULE1.color
+                "SCHEDULE2" -> ScheduleColorType.SCHEDULE2.color
+                "SCHEDULE3" -> ScheduleColorType.SCHEDULE3.color
+                "SCHEDULE4" -> ScheduleColorType.SCHEDULE4.color
+                "SCHEDULE5" -> ScheduleColorType.SCHEDULE5.color
+                else -> ScheduleColorType.SCHEDULE1.color
+            }
+        }
+    } catch (e: Exception) {
+        ScheduleColorType.SCHEDULE1.color
     }
 
     if (totalSlots <= 2) {

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/ParentAddPlanScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/ParentAddPlanScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -19,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kiero.R
+import com.kiero.core.common.extension.collectSideEffect
 import com.kiero.core.designsystem.component.KieroTopbar
 import com.kiero.core.designsystem.theme.KieroTheme
 import com.kiero.core.model.trigger.SnackbarState
@@ -43,19 +43,18 @@ fun ParentScheduleAddRoute(
     val uiState by viewModel.state.collectAsStateWithLifecycle()
     val globalTrigger = LocalGlobalUiEventTrigger.current
 
-    LaunchedEffect(Unit) {
-        viewModel.sideEffect.collect { effect ->
-            when (effect) {
-                is ParentPlanSideEffect.ShowSnackBar -> globalTrigger.showSnackbar(
-                    SnackbarState(effect.message)
-                )
+    viewModel.sideEffect.collectSideEffect { effect ->
+        when (effect) {
+            is ParentPlanSideEffect.ShowSnackBar -> globalTrigger.showSnackbar(
+                SnackbarState(effect.message)
+            )
 
-                is ParentPlanSideEffect.navigateUp -> {
-                    navigateUp()
-                }
-
+            is ParentPlanSideEffect.navigateUp -> {
+                navigateUp()
             }
+
         }
+
     }
 
     ScheduleAddScreen(

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/ParentAddPlanScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/ParentAddPlanScreen.kt
@@ -9,66 +9,110 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kiero.R
 import com.kiero.core.designsystem.component.KieroTopbar
 import com.kiero.core.designsystem.theme.KieroTheme
+import com.kiero.core.model.trigger.SnackbarState
+import com.kiero.core.trigger.LocalGlobalUiEventTrigger
 import com.kiero.presentation.parent.schedule.plan.component.picker.ColorPickerBottomSheet
 import com.kiero.presentation.parent.schedule.plan.component.plan.ScheduleDatebar
-import com.kiero.presentation.parent.schedule.plan.component.select.ScheduleTextField
-import com.kiero.presentation.parent.schedule.plan.component.select.WeekSelectArea
 import com.kiero.presentation.parent.schedule.plan.component.select.ColorSelectArea
-import com.kiero.presentation.parent.schedule.screen.component.TimeSelectArea
+import com.kiero.presentation.parent.schedule.plan.component.select.ScheduleTextField
+import com.kiero.presentation.parent.schedule.plan.component.select.TimeSelectArea
+import com.kiero.presentation.parent.schedule.plan.component.select.WeekSelectArea
+import com.kiero.presentation.parent.schedule.plan.model.ColorType
+import com.kiero.presentation.parent.schedule.plan.state.ParentPlanSideEffect
+import com.kiero.presentation.parent.schedule.plan.viewmodel.ParentPlanViewModel
 
 
 @Composable
 fun ParentScheduleAddRoute(
     paddingValues: PaddingValues,
     navigateUp: () -> Unit,
+    viewModel: ParentPlanViewModel = hiltViewModel(),
 ) {
-    val textState = rememberTextFieldState()
-    var selectedColor by remember { mutableStateOf<Color?>(null) }
-    var showColorPicker by remember { mutableStateOf(false) }
+    val uiState by viewModel.state.collectAsStateWithLifecycle()
+    val globalTrigger = LocalGlobalUiEventTrigger.current
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is ParentPlanSideEffect.ShowSnackBar -> globalTrigger.showSnackbar(
+                    SnackbarState(effect.message)
+                )
+
+                is ParentPlanSideEffect.navigateUp -> {
+                    navigateUp()
+                }
+
+            }
+        }
+    }
 
     ScheduleAddScreen(
         paddingValues = paddingValues,
         navigateUp = navigateUp,
-        textState = textState,
-        selectedColor = selectedColor,
-        onColorClick = { showColorPicker = true }
+        textState = viewModel.textState,
+        selectedDays = uiState.selectedDays,
+        onDayClick = viewModel::onDayClick,
+        onAllDaysSelect = viewModel::onAllDaysSelect,
+        isRecurring = uiState.isRecurring,
+        onRecurringToggle = viewModel::onRecurringToggle,
+        selectedColorType = uiState.selectedColorType,
+        dateRangeText = uiState.dateRangeText,
+        startTime = uiState.startTime,
+        endTime = uiState.endTime,
+        onTimeSelected = viewModel::onTimeSelected,
+        isPreviousEnabled = uiState.canGoToPrevious,
+        onPreviousWeek = viewModel::onPreviousWeek,
+        onNextWeek = viewModel::onNextWeek,
+        onColorClick = { viewModel.toggleColorPicker(true) },
+        onCreatePlan = { viewModel.onCreatePlanClick() }
     )
 
-    if (showColorPicker) {
+    if (uiState.showColorPicker) {
         ColorPickerBottomSheet(
-            selectedColor = selectedColor ?: Color(0xFFCFFFFA),
-            onColorSelected = { color ->
-                selectedColor = color
+            selectedColorType = uiState.selectedColorType,
+            onColorConfirmed = { confirmedColorType ->
+                viewModel.onColorSelected(confirmedColorType)
             },
-            onDismissRequest = { showColorPicker = false }
+            onDismissRequest = { viewModel.toggleColorPicker(false) }
         )
     }
 }
-
 
 @Composable
 fun ScheduleAddScreen(
     paddingValues: PaddingValues,
     navigateUp: () -> Unit,
     textState: TextFieldState,
-    selectedColor: Color?,
+    selectedDays: Set<Int>,
+    onAllDaysSelect: (Boolean) -> Unit,
+    isRecurring: Boolean,
+    onDayClick: (Int) -> Unit,
+    onRecurringToggle: () -> Unit,
+    selectedColorType: ColorType?,
+    dateRangeText: String,
+    startTime: String,
+    endTime: String,
+    onTimeSelected: (Boolean, String) -> Unit,
+    isPreviousEnabled: Boolean,
+    onPreviousWeek: () -> Unit,
+    onNextWeek: () -> Unit,
     onColorClick: () -> Unit,
+    onCreatePlan: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -84,13 +128,14 @@ fun ScheduleAddScreen(
             leftIconRes = R.drawable.ic_close_light,
             rightIconRes = R.drawable.ic_check,
             leftIconClick = navigateUp,
-            rightIconClick = { }
+            rightIconClick = onCreatePlan
         )
 
         ScheduleDatebar(
-            date = "12.8(월) - 12.14(일)",
-            onPreviousClick = { },
-            onNextClick = { }
+            date = dateRangeText,
+            onPreviousClick = onPreviousWeek,
+            onNextClick = onNextWeek,
+            isPreviousEnabled = isPreviousEnabled
         )
 
         ScheduleTextField(
@@ -98,14 +143,24 @@ fun ScheduleAddScreen(
             placeholder = "이름을 입력해주세요",
         )
 
-        WeekSelectArea()
+        WeekSelectArea(
+            selectedDays = selectedDays,
+            isRecurring = isRecurring,
+            onDayClick = onDayClick,
+            onAllDaysSelect = onAllDaysSelect,
+            onRecurringToggle = onRecurringToggle
+        )
 
-        TimeSelectArea()
+        TimeSelectArea(
+            startTime = startTime,
+            endTime = endTime,
+            onTimeSelected = onTimeSelected
+        )
 
         Spacer(modifier = Modifier.height(8.dp))
 
         ColorSelectArea(
-            selectColor = selectedColor,
+            selectedColorType = selectedColorType,
             onColorClick = onColorClick
         )
     }
@@ -115,12 +170,9 @@ fun ScheduleAddScreen(
 @Composable
 private fun ParentAddPlanScreenPreview() {
     KieroTheme {
-        ScheduleAddScreen(
+        ParentScheduleAddRoute(
             paddingValues = PaddingValues(),
-            navigateUp = {},
-            textState = rememberTextFieldState(),
-            selectedColor = null,
-            onColorClick = {}
+            navigateUp = {}
         )
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/ParentPlanScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/ParentPlanScreen.kt
@@ -9,21 +9,32 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kiero.core.designsystem.theme.KieroTheme
-import com.kiero.presentation.parent.schedule.model.ScheduleEvent
 import com.kiero.presentation.parent.schedule.plan.component.plan.ScheduleDatebar
 import com.kiero.presentation.parent.schedule.plan.component.plan.ScheduleTimeTable
-import com.kiero.presentation.parent.schedule.plan.model.ScheduleData
+import com.kiero.presentation.parent.schedule.plan.component.plan.ScheduleWeekTopbar
+import com.kiero.presentation.parent.schedule.plan.state.ParentScheduleState
+import com.kiero.presentation.parent.schedule.plan.state.toScheduleEvent
 
 @Composable
 fun ParentPlanScreen(
-    events: List<ScheduleEvent>,
+    state: ParentScheduleState,
+    onDateChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val events = remember(state.planAllModel) {
+        val recurring =
+            state.planAllModel?.recurringSchedules?.map { it.toScheduleEvent() } ?: emptyList()
+        val normal =
+            state.planAllModel?.normalSchedules?.map { it.toScheduleEvent() } ?: emptyList()
+        recurring + normal
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -35,20 +46,24 @@ fun ParentPlanScreen(
         Spacer(modifier = Modifier.height(15.dp))
 
         ScheduleDatebar(
-            date = "12월 4주차",
-            onPreviousClick = {},
-            onNextClick = {}
+            date = state.dateRangeText,
+            onPreviousClick = { onDateChange(false) },
+            onNextClick = { onDateChange(true) }
         )
 
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(
-                    color = KieroTheme.colors.black
-                ),
-        ) {
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
             item {
-                ScheduleTimeTable(events = events)
+                ScheduleWeekTopbar(
+                    currentDate = state.currentDate
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+            item {
+                ScheduleTimeTable(
+                    state = state,
+                    events = events
+                )
             }
         }
     }
@@ -59,7 +74,8 @@ fun ParentPlanScreen(
 private fun ParentPlanScreenPreview() {
     KieroTheme {
         ParentPlanScreen(
-            events = ScheduleData.fakeScheduleEvents
+            state = ParentScheduleState(),
+            onDateChange = {}
         )
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/ParentPlanScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/ParentPlanScreen.kt
@@ -19,7 +19,7 @@ import com.kiero.presentation.parent.schedule.plan.component.plan.ScheduleDateba
 import com.kiero.presentation.parent.schedule.plan.component.plan.ScheduleTimeTable
 import com.kiero.presentation.parent.schedule.plan.component.plan.ScheduleWeekTopbar
 import com.kiero.presentation.parent.schedule.plan.state.ParentScheduleState
-import com.kiero.presentation.parent.schedule.plan.state.toScheduleEvent
+import com.kiero.presentation.parent.schedule.plan.state.toUiModel
 
 @Composable
 fun ParentPlanScreen(
@@ -28,12 +28,14 @@ fun ParentPlanScreen(
     modifier: Modifier = Modifier,
 ) {
     val events = remember(state.planAllModel) {
-        val recurring =
-            state.planAllModel?.recurringSchedules?.map { it.toScheduleEvent() } ?: emptyList()
-        val normal =
-            state.planAllModel?.normalSchedules?.map { it.toScheduleEvent() } ?: emptyList()
-        recurring + normal
+        state.planAllModel?.let { model ->
+            buildList {
+                addAll(model.recurringSchedules.map { it.toUiModel() })
+                addAll(model.normalSchedules.map { it.toUiModel() })
+            }
+        } ?: emptyList()
     }
+
 
     Column(
         modifier = modifier

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/picker/ColorPicker.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/picker/ColorPicker.kt
@@ -1,6 +1,7 @@
 package com.kiero.presentation.parent.schedule.plan.component.picker
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,11 +17,16 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -32,12 +38,16 @@ import com.kiero.presentation.parent.schedule.plan.model.ColorType
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ColorPickerBottomSheet(
-    selectedColor: Color,
-    onColorSelected: (Color) -> Unit,
+    selectedColorType: ColorType,
+    onColorConfirmed: (ColorType) -> Unit,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val sheetState = rememberModalBottomSheetState()
+
+
+    var tempColorType by remember { mutableStateOf(selectedColorType) }
+
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
@@ -45,6 +55,10 @@ fun ColorPickerBottomSheet(
         containerColor = KieroTheme.colors.gray900,
         dragHandle = null,
         modifier = modifier
+            .pointerInput(Unit) {
+                detectTapGestures {
+                }
+            }
     ) {
         Column(
             modifier = Modifier
@@ -56,14 +70,17 @@ fun ColorPickerBottomSheet(
                 leftIconRes = R.drawable.ic_close_light,
                 leftIconClick = onDismissRequest,
                 rightIconRes = R.drawable.ic_check,
-                rightIconClick = onDismissRequest,
+                rightIconClick = {
+                    onColorConfirmed(tempColorType)
+                },
             )
 
             Spacer(modifier = Modifier.height(25.dp))
 
             ColorPicker(
-                selectedColor = selectedColor,
-                onColorSelected = onColorSelected,
+                selectedColorType = tempColorType,
+                onColorSelected = { colorType -> tempColorType = colorType },
+                modifier = Modifier.padding(horizontal = 16.dp)
             )
 
             Spacer(modifier = Modifier.height(125.dp))
@@ -73,8 +90,8 @@ fun ColorPickerBottomSheet(
 
 @Composable
 fun ColorPicker(
-    selectedColor: Color,
-    onColorSelected: (Color) -> Unit,
+    selectedColorType: ColorType,
+    onColorSelected: (ColorType) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -86,8 +103,8 @@ fun ColorPicker(
         ColorType.entries.forEach { colorType ->
             ColorPickerItem(
                 selectColor = colorType.color,
-                isSelected = selectedColor == colorType.color,
-                onClick = { onColorSelected(colorType.color) },
+                isSelected = selectedColorType == colorType,
+                onClick = { onColorSelected(colorType) },
             )
         }
     }
@@ -128,8 +145,8 @@ private fun ColorPickerPreview() {
     KieroTheme {
         Column(modifier = Modifier.padding(16.dp)) {
             ColorPicker(
-                selectedColor = ColorType.SCHEDULE1.color,
-                onColorSelected = {}
+                selectedColorType = ColorType.SCHEDULE2,
+                onColorSelected = {},
             )
         }
     }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/picker/TimePicker.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/picker/TimePicker.kt
@@ -2,6 +2,7 @@ package com.kiero.presentation.parent.schedule.plan.component.picker
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -107,6 +108,7 @@ fun TimePicker(
 fun TimePickerBottomSheet(
     onSelected: (String) -> Unit,
     onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val sheetState = rememberModalBottomSheetState()
 
@@ -124,7 +126,12 @@ fun TimePickerBottomSheet(
         onDismissRequest = onDismissRequest,
         sheetState = sheetState,
         containerColor = KieroTheme.colors.gray900,
-        dragHandle = {}
+        dragHandle = {},
+        modifier = modifier
+            .pointerInput(Unit) {
+                detectTapGestures {
+                }
+            }
     ) {
         Column(
             modifier = Modifier
@@ -256,7 +263,7 @@ fun TimeItemsPicker(
             override fun onPostScroll(
                 consumed: Offset,
                 available: Offset,
-                source: NestedScrollSource
+                source: NestedScrollSource,
             ): Offset {
                 return available
             }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/plan/ScheduleDatebar.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/plan/ScheduleDatebar.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -27,6 +26,7 @@ fun ScheduleDatebar(
     onPreviousClick: () -> Unit,
     onNextClick: () -> Unit,
     modifier: Modifier = Modifier,
+    isPreviousEnabled: Boolean = true,
 ) {
     Row(
         modifier = modifier
@@ -41,9 +41,11 @@ fun ScheduleDatebar(
         Icon(
             imageVector = ImageVector.vectorResource(id = R.drawable.ic_arrow_left),
             contentDescription = null,
-            tint = Color.Unspecified,
-            modifier = Modifier
-                .noRippleClickable(onClick = onPreviousClick)
+
+            tint = if (isPreviousEnabled) KieroTheme.colors.white else KieroTheme.colors.gray600,
+            modifier = Modifier.noRippleClickable(
+                onClick = { if (isPreviousEnabled) onPreviousClick() }
+            )
         )
 
         Spacer(modifier = Modifier.width(44.dp))

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/plan/SchedulePlanner.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/plan/SchedulePlanner.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -22,13 +23,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kiero.core.designsystem.theme.KieroTheme
 import com.kiero.presentation.parent.schedule.model.ScheduleEvent
-import com.kiero.presentation.parent.schedule.model.toDayIndex
 import com.kiero.presentation.parent.schedule.model.toScheduleBlocks
-import com.kiero.presentation.parent.schedule.plan.model.ScheduleData
-
+import com.kiero.presentation.parent.schedule.plan.state.ParentScheduleState
 
 @Composable
 fun ScheduleTimeTable(
+    state: ParentScheduleState,
     events: List<ScheduleEvent>,
     modifier: Modifier = Modifier,
 ) {
@@ -37,16 +37,12 @@ fun ScheduleTimeTable(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(11.dp)
     ) {
-        ScheduleWeekTopbar(
-            dayList = ScheduleData.fakeDayList
-        )
-
         Row(
             modifier = Modifier.fillMaxWidth()
         ) {
             ScheduleTimeColumn()
 
-            SchedulePlanner(events = events)
+            SchedulePlanner(events = events, state = state)
         }
     }
 }
@@ -54,6 +50,7 @@ fun ScheduleTimeTable(
 @Composable
 fun SchedulePlanner(
     events: List<ScheduleEvent>,
+    state: ParentScheduleState,
     modifier: Modifier = Modifier,
     daysCount: Int = 7,
 ) {
@@ -61,8 +58,11 @@ fun SchedulePlanner(
     val hourHeight = with(density) { 38.dp.roundToPx().toDp() }
 
     val allBlocks = events.flatMap { event ->
-        val dayIndex = event.dayOfWeek?.toDayIndex() ?: 0
-        event.toScheduleBlocks(dayIndex)
+        val indices = state.run { event.getIndices() }
+
+        indices.flatMap { index ->
+            event.toScheduleBlocks(index)
+        }
     }
 
     BoxWithConstraints(
@@ -74,20 +74,43 @@ fun SchedulePlanner(
             .padding(4.dp)
     ) {
         val dayWidth = maxWidth / daysCount
-
-        allBlocks.forEach { block ->
-            val topOffset = hourHeight * (block.startHour - 8)
-            val blockHeight = hourHeight * block.durationInSlots
-
+        if (events.isEmpty()) {
             Box(
-                modifier = Modifier
-                    .offset(x = dayWidth * block.dayIndex, y = topOffset)
-                    .width(dayWidth)
-                    .height(blockHeight)
-                    .padding(horizontal = 3.dp)
+                modifier = modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
             ) {
-                ScheduleEventBlock(block = block)
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        text = "등록된 일정이 없어요",
+                        style = KieroTheme.typography.semiBold.title4,
+                        color = KieroTheme.colors.gray400
+                    )
+                    Text(
+                        text = "아이의 일정을 추가해 보세요!",
+                        style = KieroTheme.typography.semiBold.title4,
+                        color = KieroTheme.colors.gray400
+                    )
+                }
             }
+        } else {
+            allBlocks.forEach { block ->
+                val topOffset = hourHeight * (block.startHour - 8)
+                val blockHeight = hourHeight * block.durationInSlots
+
+                Box(
+                    modifier = Modifier
+                        .offset(x = dayWidth * block.dayIndex, y = topOffset)
+                        .width(dayWidth)
+                        .height(blockHeight)
+                        .padding(horizontal = 3.dp)
+                ) {
+                    ScheduleEventBlock(block = block)
+                }
+            }
+
         }
     }
 }
@@ -96,49 +119,6 @@ fun SchedulePlanner(
 @Composable
 private fun ScheduleTimeTablePreview() {
     KieroTheme {
-        ScheduleTimeTable(
-            events = listOf(
-                ScheduleEvent(
-                    id = "1",
-                    name = "학교",
-                    isRecurring = true,
-                    startTime = "08:00",
-                    endTime = "12:00",
-                    scheduleColor = "SCHEDULE4",
-                    dayOfWeek = "MON",
-                    date = null
-                ),
-                ScheduleEvent(
-                    id = "2",
-                    name = "수영",
-                    isRecurring = true,
-                    startTime = "08:00",
-                    endTime = "13:00",
-                    scheduleColor = "SCHEDULE2",
-                    dayOfWeek = "TUE",
-                    date = null
-                ),
-                ScheduleEvent(
-                    id = "5",
-                    name = "수영",
-                    isRecurring = true,
-                    startTime = "08:00",
-                    endTime = "9:00",
-                    scheduleColor = "SCHEDULE2",
-                    dayOfWeek = "WED",
-                    date = null
-                ),
-                ScheduleEvent(
-                    id = "3",
-                    name = "태권도",
-                    isRecurring = true,
-                    startTime = "14:00",
-                    endTime = "16:00",
-                    scheduleColor = "SCHEDULE2",
-                    dayOfWeek = "TUE",
-                    date = null
-                ),
-            )
-        )
+        // Preview implementation
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/plan/ScheduleWeekTopbar.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/plan/ScheduleWeekTopbar.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kiero.core.designsystem.theme.KieroTheme
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -24,12 +25,12 @@ fun ScheduleWeekTopbar(
     currentDate: LocalDate,
     modifier: Modifier = Modifier,
 ) {
-    val weekDaysList = remember(currentDate) {
-        val monday = currentDate.with(java.time.DayOfWeek.MONDAY)
-        val formatter = DateTimeFormatter.ofPattern("d(E)", Locale.KOREAN)
+   val DAY_FORMATTER = DateTimeFormatter.ofPattern("d(E)", Locale.KOREAN)
 
-        (0..6).map { offset ->
-            monday.plusDays(offset.toLong()).format(formatter)
+    val weekDaysList = remember(currentDate) {
+        val startOfWeek = currentDate.with(DayOfWeek.MONDAY)
+        (0L..6L).map { offset ->
+            startOfWeek.plusDays(offset).format(DAY_FORMATTER)
         }
     }
 

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/plan/ScheduleWeekTopbar.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/plan/ScheduleWeekTopbar.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -14,34 +15,39 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kiero.core.designsystem.theme.KieroTheme
-import com.kiero.presentation.parent.schedule.plan.model.DayList
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toPersistentList
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 @Composable
 fun ScheduleWeekTopbar(
-    dayList: ImmutableList<DayList>,
+    currentDate: LocalDate,
     modifier: Modifier = Modifier,
 ) {
+    val weekDaysList = remember(currentDate) {
+        val monday = currentDate.with(java.time.DayOfWeek.MONDAY)
+        val formatter = DateTimeFormatter.ofPattern("d(E)", Locale.KOREAN)
+
+        (0..6).map { offset ->
+            monday.plusDays(offset.toLong()).format(formatter)
+        }
+    }
 
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .background(
-                color = Color.Unspecified
-            )
+            .background(color = Color.Unspecified)
             .padding(start = 28.dp, end = 7.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(3.dp)
     ) {
-        dayList.forEachIndexed { index, date ->
+        weekDaysList.forEachIndexed { index, day ->
             Text(
-                text = date.day,
+                text = day,
                 color = if (index == 0) KieroTheme.colors.main else KieroTheme.colors.gray100,
                 style = KieroTheme.typography.regular.body5,
                 textAlign = TextAlign.Center,
-                modifier = Modifier
-                    .weight(1f)
+                modifier = Modifier.weight(1f)
             )
         }
     }
@@ -52,15 +58,7 @@ fun ScheduleWeekTopbar(
 private fun WeekTopbarPreview() {
     KieroTheme {
         ScheduleWeekTopbar(
-            dayList = listOf(
-                DayList("8(월)"),
-                DayList("9(화)"),
-                DayList("10(수)"),
-                DayList("11(목)"),
-                DayList("12(금)"),
-                DayList("13(토)"),
-                DayList("14(일)")
-            ).toPersistentList()
+            currentDate = LocalDate.of(2026, 1, 20)
         )
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/select/ColorSelectArea.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/select/ColorSelectArea.kt
@@ -22,10 +22,11 @@ import androidx.compose.ui.unit.dp
 import com.kiero.R
 import com.kiero.core.common.extension.noRippleClickable
 import com.kiero.core.designsystem.theme.KieroTheme
+import com.kiero.presentation.parent.schedule.plan.model.ColorType
 
 @Composable
 fun ColorSelectArea(
-    selectColor: Color?,
+    selectedColorType: ColorType?,
     onColorClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -45,13 +46,13 @@ fun ColorSelectArea(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        if (selectColor != null) {
+        if (selectedColorType != null) {
             Box(
                 modifier = Modifier
                     .size(35.dp)
                     .clip(RoundedCornerShape(5.dp))
                     .background(
-                        color = selectColor,
+                        color = selectedColorType.color,
                         shape = RoundedCornerShape(5.dp)
                     )
             )
@@ -73,7 +74,7 @@ fun ColorSelectArea(
 private fun PreviewColorSelectAreaPreivew() {
     KieroTheme {
         ColorSelectArea(
-            selectColor = null,
+            selectedColorType = ColorType.SCHEDULE2,
             onColorClick = {}
         )
     }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/select/TimeSelectArea.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/select/TimeSelectArea.kt
@@ -1,4 +1,4 @@
-package com.kiero.presentation.parent.schedule.screen.component
+package com.kiero.presentation.parent.schedule.plan.component.select
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -30,10 +30,12 @@ import com.kiero.presentation.parent.schedule.plan.component.picker.TimePickerBo
 
 @Composable
 fun TimeSelectArea(
+    startTime: String,
+    endTime: String,
+    onTimeSelected: (Boolean, String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var startTime by remember { mutableStateOf("12:00 PM") }
-    var endTime by remember { mutableStateOf("12:00 PM") }
+
     var showStartTimePicker by remember { mutableStateOf(false) }
     var showEndTimePicker by remember { mutableStateOf(false) }
 
@@ -83,7 +85,7 @@ fun TimeSelectArea(
     if (showStartTimePicker) {
         TimePickerBottomSheet(
             onSelected = { time ->
-                startTime = time.validateAsStartTime()
+                onTimeSelected(true, time.validateAsStartTime())
                 showStartTimePicker = false
             },
             onDismissRequest = { showStartTimePicker = false }
@@ -93,7 +95,7 @@ fun TimeSelectArea(
     if (showEndTimePicker) {
         TimePickerBottomSheet(
             onSelected = { time ->
-                endTime = time
+                onTimeSelected(false, time)
                 showEndTimePicker = false
             },
             onDismissRequest = { showEndTimePicker = false }
@@ -151,6 +153,10 @@ private fun TimeBlock(
 @Composable
 private fun TimeSelectAreaPreview() {
     KieroTheme {
-        TimeSelectArea()
+//        TimeSelectArea(
+//            startTime = "12:00",
+//            endTime = "15:00",
+//            onTimeSelected = (true,"")
+//        )
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/select/WeekSelectArea.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/select/WeekSelectArea.kt
@@ -16,10 +16,6 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
@@ -37,11 +33,14 @@ import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 fun WeekSelectArea(
+    selectedDays: Set<Int>,
+    isRecurring: Boolean,
+    onDayClick: (Int) -> Unit,
+    onAllDaysSelect: (Boolean) -> Unit,
+    onRecurringToggle: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var selectedDays by remember { mutableStateOf(setOf<Int>()) }
-    var isRepeatEnabled by remember { mutableStateOf(false) }
-    var isWeeklyRepeatEnabled by remember { mutableStateOf(false) }
+
 
     Column(
         modifier = modifier
@@ -56,36 +55,19 @@ fun WeekSelectArea(
         verticalArrangement = Arrangement.spacedBy(18.dp)
     ) {
         DaySection(
-            onValidClick = {
-                isWeeklyRepeatEnabled = !isWeeklyRepeatEnabled
-            },
-            isEnabled = isWeeklyRepeatEnabled
+            onValidClick = onRecurringToggle,
+            isEnabled = isRecurring
         )
 
         DayPickSection(
             selectedDays = selectedDays,
-            onDayClick = { dayIndex ->
-                selectedDays = if (selectedDays.contains(dayIndex)) {
-                    selectedDays - dayIndex
-                } else {
-                    selectedDays + dayIndex
-                }
-                if (isRepeatEnabled) {
-                    isRepeatEnabled = false
-                }
-            }
+            onDayClick = onDayClick
         )
-
         RepeatSection(
-            onAbleClick = { currentState ->
-                isRepeatEnabled = !currentState
-                selectedDays = if (!currentState) {
-                    setOf(0, 1, 2, 3, 4, 5, 6)
-                } else {
-                    emptySet()
-                }
+            onAbleClick = { isEnabled ->
+                onAllDaysSelect(isEnabled)
             },
-            isEnabled = isRepeatEnabled
+            isEnabled = selectedDays.size == 7
         )
 
     }
@@ -259,7 +241,9 @@ private fun DayToggle(
 private fun PreviewDayBox() {
     KieroTheme {
         Column {
-            WeekSelectArea()
+//            WeekSelectArea(
+//
+//            )
         }
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/model/PlanModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/model/PlanModel.kt
@@ -10,12 +10,20 @@ data class DayList(
     val day: String,
 )
 
-enum class ColorType(val color: Color) {
-    SCHEDULE1(Color(0xFFCFFFFA)),
-    SCHEDULE2(Color(0xFFFFFEE9)),
-    SCHEDULE3(Color(0xFFBFFFE3)),
-    SCHEDULE4(Color(0xFF34D9D3)),
-    SCHEDULE5(Color(0xFF7BBDFF)),
+enum class ColorType(val color: Color, val hexCode: String) {
+    SCHEDULE1(Color(0xFFCFFFFA), "#CFFFFA"),
+    SCHEDULE2(Color(0xFFFFFEE9), "#FFFEE9"),
+    SCHEDULE3(Color(0xFFBFFFE3), "#BFFFE3"),
+    SCHEDULE4(Color(0xFF34D9D3), "#34D9D3"),
+    SCHEDULE5(Color(0xFF7BBDFF), "#7BBDFF");
+
+    companion object {
+        fun fromHexCode(hexCode: String): ColorType {
+            return entries.find {
+                it.hexCode.equals(hexCode, ignoreCase = true)
+            } ?: SCHEDULE1
+        }
+    }
 }
 
 

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/state/PlanScheduleState.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/state/PlanScheduleState.kt
@@ -51,7 +51,7 @@ data class ParentScheduleState(
 
 }
 
-fun RecurringScheduleModel.toScheduleEvent() = ScheduleEvent(
+fun RecurringScheduleModel.toUiModel() = ScheduleEvent(
     id = "recurring_${name}_${startTime}",
     name = name,
     isRecurring = true,
@@ -62,7 +62,7 @@ fun RecurringScheduleModel.toScheduleEvent() = ScheduleEvent(
     date = null
 )
 
-fun NormalScheduleModel.toScheduleEvent() = ScheduleEvent(
+fun NormalScheduleModel.toUiModel() = ScheduleEvent(
     id = "normal_${name}_${date}",
     name = name,
     isRecurring = false,

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/state/PlanScheduleState.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/state/PlanScheduleState.kt
@@ -1,0 +1,74 @@
+package com.kiero.presentation.parent.schedule.plan.state
+
+import com.kiero.data.parent.plan.model.NormalScheduleModel
+import com.kiero.data.parent.plan.model.PlanAllModel
+import com.kiero.data.parent.plan.model.RecurringScheduleModel
+import com.kiero.presentation.parent.schedule.model.ScheduleEvent
+import com.kiero.presentation.signup.parent.model.ParentInfoUiModel
+import java.time.DayOfWeek
+import java.time.LocalDate
+
+data class ParentScheduleState(
+    val planAllModel: PlanAllModel? = null,
+    val parentInfo: ParentInfoUiModel = ParentInfoUiModel(),
+    val currentDate: LocalDate = LocalDate.now(),
+    val isFetching: Boolean = false,
+) {
+    val dateRangeText: String
+        get() {
+            val monday = currentDate.with(DayOfWeek.MONDAY)
+            val sunday = currentDate.with(DayOfWeek.SUNDAY)
+            return "${monday.monthValue}월 ${((monday.dayOfMonth - 1) / 7) + 1}주차"
+        }
+
+    fun ScheduleEvent.getIndices(): List<Int> {
+        return if (isRecurring) {
+            this.dayOfWeek?.split(",")?.mapNotNull { day ->
+                day.trim().toDayIndex()
+            } ?: listOf(0)
+        } else {
+            try {
+                val localDate = java.time.LocalDate.parse(this.date)
+                listOf(localDate.dayOfWeek.value - 1)
+            } catch (e: Exception) {
+                listOf(0)
+            }
+        }
+    }
+
+    fun String.toDayIndex(): Int {
+        return when (this.uppercase()) {
+            "MON" -> 0
+            "TUE" -> 1
+            "WED" -> 2
+            "THU" -> 3
+            "FRI" -> 4
+            "SAT" -> 5
+            "SUN" -> 6
+            else -> 0
+        }
+    }
+
+}
+
+fun RecurringScheduleModel.toScheduleEvent() = ScheduleEvent(
+    id = "recurring_${name}_${startTime}",
+    name = name,
+    isRecurring = true,
+    startTime = startTime,
+    endTime = endTime,
+    scheduleColor = colorCode,
+    dayOfWeek = dayOfWeek,
+    date = null
+)
+
+fun NormalScheduleModel.toScheduleEvent() = ScheduleEvent(
+    id = "normal_${name}_${date}",
+    name = name,
+    isRecurring = false,
+    startTime = startTime,
+    endTime = endTime,
+    scheduleColor = colorCode,
+    dayOfWeek = null,
+    date = date
+)

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/state/PlanState.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/state/PlanState.kt
@@ -1,0 +1,121 @@
+package com.kiero.presentation.parent.schedule.plan.state
+
+import androidx.compose.runtime.Immutable
+import com.kiero.presentation.parent.schedule.plan.model.ColorType
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.temporal.TemporalAdjusters
+import java.util.Locale
+
+@Immutable
+data class ParentPlanState(
+    val selectedColorType: ColorType = ColorType.SCHEDULE1,
+    val showColorPicker: Boolean = false,
+    val isRecurring: Boolean = false,
+    val selectedDays: Set<Int> = emptySet(),
+    val startTime: String = "12:00 PM",
+    val endTime: String = "01:00 PM",
+    val selectedDate: String = LocalDate.now().toString(),
+    val currentReferenceDate: LocalDate = LocalDate.now(),
+    val isLoading: Boolean = false,
+) {
+
+    val formattedDays: String?
+        get() = if (isRecurring && selectedDays.isNotEmpty()) {
+            selectedDays.sorted().joinToString(", ") {
+                when (it) {
+                    0 -> "MON"
+                    1 -> "TUE"
+                    2 -> "WED"
+                    3 -> "THU"
+                    4 -> "FRI"
+                    5 -> "SAT"
+                    else -> "SUN"
+                }
+            }
+        } else null
+
+    val isTimeValid: Boolean
+        get() = timeToMinutes(endTime) > timeToMinutes(startTime)
+
+    fun formatTimeForServer(time: String): String {
+        return try {
+            if (time.isEmpty()) return "00:00:00"
+            val parts = time.split(" ", ":")
+            if (parts.size < 3) return "00:00:00"
+
+            var hour = parts[0].toIntOrNull() ?: 0
+            val minute = parts[1]
+            val amPm = parts[2]
+
+            when {
+                amPm == "PM" && hour < 12 -> hour += 12
+                amPm == "AM" && hour == 12 -> hour = 0
+            }
+            String.format("%02d:%s:00", hour, minute)
+        } catch (e: Exception) {
+            "00:00:00"
+        }
+    }
+
+    val dateRangeText: String
+        get() {
+            val monday =
+                currentReferenceDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+            val sunday = monday.plusDays(6)
+
+            val formatter = DateTimeFormatter.ofPattern("M.d(E)", Locale.KOREAN)
+            return "${monday.format(formatter)} - ${sunday.format(formatter)}"
+        }
+
+
+    val canGoToPrevious: Boolean
+        get() {
+            val today = LocalDate.now()
+            val startOfThisWeek = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+            val startOfCurrentViewWeek =
+                currentReferenceDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+            return startOfCurrentViewWeek.isAfter(startOfThisWeek)
+        }
+
+    val weekDaysList: List<String>
+        get() {
+            val monday = currentReferenceDate.with(DayOfWeek.MONDAY)
+            val formatter =
+                DateTimeFormatter.ofPattern("d(E)", Locale.KOREAN)
+            return (0..6).map { offset ->
+                monday.plusDays(offset.toLong()).format(formatter)
+            }
+        }
+
+    private fun getWeekOfMonth(date: LocalDate): Int {
+        return ((date.dayOfMonth - 1) / 7) + 1
+    }
+
+
+    fun isTimeValid(start: String, end: String): Boolean {
+        val startVal = timeToMinutes(start)
+        val endVal = timeToMinutes(end)
+        return endVal > startVal
+    }
+
+    fun timeToMinutes(time: String): Int {
+        return try {
+            val parts = time.split(" ", ":")
+            var hour = parts[0].toInt()
+            val minute = parts[1].toInt()
+            val amPm = parts[2]
+            if (amPm == "PM" && hour < 12) hour += 12
+            if (amPm == "AM" && hour == 12) hour = 0
+            (hour * 60) + minute
+        } catch (e: Exception) {
+            0
+        }
+    }
+}
+
+sealed interface ParentPlanSideEffect {
+    data class ShowSnackBar(val message: String) : ParentPlanSideEffect
+    data object navigateUp : ParentPlanSideEffect
+}

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/viewmodel/ParentPlanViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/viewmodel/ParentPlanViewModel.kt
@@ -1,0 +1,199 @@
+package com.kiero.presentation.parent.schedule.plan.viewmodel
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kiero.data.parent.plan.repository.PlanRepository
+import com.kiero.presentation.parent.schedule.plan.model.ColorType
+import com.kiero.presentation.parent.schedule.plan.state.ParentPlanSideEffect
+import com.kiero.presentation.parent.schedule.plan.state.ParentPlanState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
+import javax.inject.Inject
+
+@HiltViewModel
+class ParentPlanViewModel @Inject constructor(
+    private val planRepository: PlanRepository,
+) : ViewModel() {
+
+
+    private val _state = MutableStateFlow(ParentPlanState())
+    val state = _state.asStateFlow()
+
+    private val _sideEffect = MutableSharedFlow<ParentPlanSideEffect>()
+    val sideEffect = _sideEffect.asSharedFlow()
+
+    val textState = TextFieldState()
+
+    init {
+        fetchDefaultColor(1L)
+    }
+
+    fun onCreatePlanClick() {
+        viewModelScope.launch {
+            val name = textState.text.toString().trim()
+            val currentState = _state.value
+
+            if (name.isBlank()) {
+                _sideEffect.emit(ParentPlanSideEffect.ShowSnackBar("일정 이름을 입력해주세요"))
+                return@launch
+            }
+            when {
+                currentState.isRecurring -> {
+                    if (currentState.selectedDays.isEmpty()) {
+                        _sideEffect.emit(ParentPlanSideEffect.ShowSnackBar("요일을 선택해주세요"))
+                        return@launch
+                    }
+                }
+
+                else -> {
+                    if (currentState.selectedDays.isEmpty()) {
+                        _sideEffect.emit(ParentPlanSideEffect.ShowSnackBar("날짜를 선택해주세요"))
+                        return@launch
+                    }
+                    if (currentState.selectedDate.isBlank()) {
+                        _sideEffect.emit(ParentPlanSideEffect.ShowSnackBar("날짜를 선택해주세요"))
+                        return@launch
+                    }
+                }
+            }
+
+            if (!currentState.isTimeValid(currentState.startTime, currentState.endTime)) {
+                _sideEffect.emit(ParentPlanSideEffect.ShowSnackBar("종료 시간은 시작 시간보다 늦어야 합니다"))
+                return@launch
+            }
+
+            val selectedColor = currentState.selectedColorType
+
+
+            _state.update { it.copy(isLoading = true) }
+
+            planRepository.postPlan(
+                childId = 1L,
+                name = name,
+                isRecurring = currentState.isRecurring,
+                startTime = currentState.formatTimeForServer(currentState.startTime),
+                endTime = currentState.formatTimeForServer(currentState.endTime),
+                scheduleColor = selectedColor.name,
+                dayOfWeek = if (currentState.isRecurring) currentState.formattedDays else null,
+                date = if (!currentState.isRecurring) currentState.selectedDate else null
+            ).onSuccess {
+                _sideEffect.emit(ParentPlanSideEffect.ShowSnackBar("일정이 등록되었습니다"))
+                kotlinx.coroutines.delay(200)
+            }.onFailure { error ->
+                val errorMessage = error.message ?: "해당 시간에 이미 등록된 일정이 있습니다"
+                _sideEffect.emit(ParentPlanSideEffect.ShowSnackBar(errorMessage))
+                _state.update { it.copy(isLoading = false) }
+            }
+        }
+    }
+
+
+    fun fetchDefaultColor(childId: Long) {
+        viewModelScope.launch {
+            planRepository.getPlanColor(childId)
+                .onSuccess { result ->
+                    val colorType = ColorType.entries.find { it.name == result.scheduleColor }
+                        ?: ColorType.SCHEDULE1
+                    _state.update { it.copy(selectedColorType = colorType) }
+                }
+        }
+    }
+
+    fun onAllDaysSelect(isCurrentlyAllSelected: Boolean) {
+        _state.update { currentState ->
+            val newDays = if (isCurrentlyAllSelected) emptySet() else (0..6).toSet()
+            currentState.copy(selectedDays = newDays)
+        }
+    }
+
+    fun onDayClick(dayIndex: Int) {
+        _state.update { currentState ->
+            val newDays = if (currentState.selectedDays.contains(dayIndex)) {
+                currentState.selectedDays - dayIndex
+            } else {
+                currentState.selectedDays + dayIndex
+            }
+
+            if (!currentState.isRecurring) {
+                val monday =
+                    currentState.currentReferenceDate.with(
+                        TemporalAdjusters.previousOrSame(
+                            DayOfWeek.MONDAY
+                        )
+                    )
+                val actualDate = monday.plusDays(dayIndex.toLong()).toString()
+                currentState.copy(selectedDays = newDays, selectedDate = actualDate)
+            } else {
+                currentState.copy(selectedDays = newDays)
+            }
+        }
+    }
+
+    fun onColorSelected(colorType: ColorType) {
+        _state.update {
+            val newState = it.copy(selectedColorType = colorType, showColorPicker = false)
+            newState
+        }
+    }
+
+    fun toggleColorPicker(isVisible: Boolean) {
+        _state.update { it.copy(showColorPicker = isVisible) }
+    }
+
+    fun onPreviousWeek() {
+        _state.update { currentState ->
+            val startOfThisWeek =
+                LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+            if (currentState.currentReferenceDate.isAfter(startOfThisWeek)) {
+                currentState.copy(
+                    currentReferenceDate = currentState.currentReferenceDate.minusWeeks(
+                        1
+                    )
+                )
+            } else currentState
+        }
+    }
+
+    fun onNextWeek() {
+        _state.update { currentState ->
+            val nextWeek = currentState.currentReferenceDate.plusWeeks(1)
+            currentState.copy(currentReferenceDate = nextWeek)
+        }
+    }
+
+    fun onRecurringToggle() {
+        _state.update { currentState ->
+            val newIsRecurring = !currentState.isRecurring
+            when {
+                newIsRecurring -> {
+                    currentState.copy(
+                        isRecurring = true,
+                        selectedDate = ""
+                    )
+                }
+
+                else -> {
+                    currentState.copy(
+                        isRecurring = false,
+                        selectedDays = emptySet(),
+                        selectedDate = ""
+                    )
+                }
+            }
+        }
+    }
+
+    fun onTimeSelected(isStart: Boolean, time: String) {
+        _state.update { if (isStart) it.copy(startTime = time) else it.copy(endTime = time) }
+    }
+
+}

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/viewmodel/ParentPlanViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/viewmodel/ParentPlanViewModel.kt
@@ -89,8 +89,7 @@ class ParentPlanViewModel @Inject constructor(
                 _sideEffect.emit(ParentPlanSideEffect.ShowSnackBar("일정이 등록되었습니다"))
                 kotlinx.coroutines.delay(200)
             }.onFailure { error ->
-                val errorMessage = error.message ?: "해당 시간에 이미 등록된 일정이 있습니다"
-                _sideEffect.emit(ParentPlanSideEffect.ShowSnackBar(errorMessage))
+                _sideEffect.emit(ParentPlanSideEffect.ShowSnackBar("해당 시간에 이미 등록된 일정이 있습니다"))
                 _state.update { it.copy(isLoading = false) }
             }
         }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/viewmodel/ParentScheduleViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/viewmodel/ParentScheduleViewModel.kt
@@ -3,10 +3,12 @@ package com.kiero.presentation.parent.schedule.viewmodel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.kiero.core.model.UiState
 import com.kiero.data.auth.repository.AuthRepository
 import com.kiero.data.parent.plan.repository.PlanRepository
 import com.kiero.presentation.parent.schedule.plan.state.ParentScheduleState
+import com.kiero.presentation.signup.parent.navigation.ParentSignUp
 import com.kiero.presentation.signup.parent.state.ParentSignUpSideEffect
 import com.kiero.presentation.signup.parent.state.ParentSignUpState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -37,19 +39,20 @@ class ParentScheduleViewModel @Inject constructor(
     private val _sideEffect = MutableSharedFlow<ParentSignUpSideEffect>()
     val sideEffect: SharedFlow<ParentSignUpSideEffect> = _sideEffect.asSharedFlow()
 
+    val info = savedStateHandle.toRoute<ParentSignUp>()
+
 
     init {
         fetchSchedule(1L)
 
-        val name = savedStateHandle.get<String>("parentName")
-        val image = savedStateHandle.get<String>("parentProfileImage")
+        val parentName = info.parentName
+        val profileImage = info.parentProfileImage
 
-        if (name != null || image != null) {
-            initFetchParentInfo(
-                parentName = name ?: "사용자",
-                parentProfileImage = image ?: ""
-            )
-        }
+        initFetchParentInfo(
+            parentName = parentName,
+            parentProfileImage = profileImage
+        )
+
 
     }
 

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/viewmodel/ParentScheduleViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/viewmodel/ParentScheduleViewModel.kt
@@ -1,0 +1,112 @@
+package com.kiero.presentation.parent.schedule.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kiero.core.model.UiState
+import com.kiero.data.auth.repository.AuthRepository
+import com.kiero.data.parent.plan.repository.PlanRepository
+import com.kiero.presentation.parent.schedule.plan.state.ParentScheduleState
+import com.kiero.presentation.signup.parent.state.ParentSignUpSideEffect
+import com.kiero.presentation.signup.parent.state.ParentSignUpState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.DayOfWeek
+import javax.inject.Inject
+
+@HiltViewModel
+class ParentScheduleViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val planRepository: PlanRepository,
+    private val authRepository: AuthRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<UiState<ParentScheduleState>>(UiState.Loading)
+    val state = _state.asStateFlow()
+
+    private val _authstate = MutableStateFlow(ParentSignUpState())
+    val authstate: StateFlow<ParentSignUpState> = _authstate.asStateFlow()
+
+    private val _sideEffect = MutableSharedFlow<ParentSignUpSideEffect>()
+    val sideEffect: SharedFlow<ParentSignUpSideEffect> = _sideEffect.asSharedFlow()
+
+
+    init {
+        fetchSchedule(1L)
+
+        val name = savedStateHandle.get<String>("parentName")
+        val image = savedStateHandle.get<String>("parentProfileImage")
+
+        if (name != null || image != null) {
+            initFetchParentInfo(
+                parentName = name ?: "사용자",
+                parentProfileImage = image ?: ""
+            )
+        }
+
+    }
+
+
+    fun fetchSchedule(childId: Long) {
+        val currentState = (_state.value as? UiState.Success)?.data ?: ParentScheduleState()
+        val monday = currentState.currentDate.with(DayOfWeek.MONDAY).toString()
+        val sunday = currentState.currentDate.with(DayOfWeek.SUNDAY).toString()
+
+        viewModelScope.launch {
+
+            _state.value = UiState.Success(currentState.copy(isFetching = true))
+            planRepository.getPlanAll(childId, monday, sunday)
+                .onSuccess { model ->
+                    _state.value = UiState.Success(
+                        currentState.copy(planAllModel = model)
+                    )
+                }
+                .onFailure {
+                    _state.value = UiState.Failure(it.message ?: "데이터 로드 실패")
+                }
+        }
+    }
+
+    fun initFetchParentInfo(
+        parentName: String,
+        parentProfileImage: String,
+    ) {
+        viewModelScope.launch {
+            _authstate.update { currentState ->
+                currentState.copy(
+                    parentInfo = currentState.parentInfo.copy(
+                        parentName = parentName,
+                        parentProfileImage = parentProfileImage
+                    )
+                )
+            }
+        }
+    }
+
+    fun logOut() {
+        viewModelScope.launch {
+            authRepository.postLogout()
+
+            _sideEffect.emit(ParentSignUpSideEffect.NavigateToSelection)
+        }
+    }
+
+
+    fun onDateChange(isNext: Boolean) {
+        val currentState = (_state.value as? UiState.Success)?.data ?: return
+        val newDate =
+            if (isNext) currentState.currentDate.plusWeeks(1) else currentState.currentDate.minusWeeks(
+                1
+            )
+        _state.value = UiState.Success(currentState.copy(currentDate = newDate))
+        fetchSchedule(1L)
+    }
+}
+


### PR DESCRIPTION
## ISSUE
- closed #50 

## ❗ WORK DESCRIPTION
- 1차 QA 반영
1. 일정 추가 - 컬러 시트 패딩 및 초기값 조정
2. 일정 메인 - FAB 버튼 위치 및 content 영역 조정
3. 미션 추가 - 유효성 검사 및 snackbar 설정
4. 미션 추가 - DatePicker 초기 값 및 영역 조정

- API 연동
1. 일정 조회 API 연동
상단 topbar 를 localDate 와 연동 및 날짜 조정했습니다.
일정이 empty 인 상황에 대한 view 작업 완료했습니다.
서버에서 불러온 일정에 대한 정보 확인 및 UI 연동했습니다.

2. 일정 추가 API 연동
텍스트, 요일 선택, 시간 선택 에 대한 유효성 검사 및 스낵바 추가했습니다.
매주 반복, 매일 반복에 대한 날짜 처리와 서버 요청 작업했습니다
(매일 반복은 현재 서버쌤들과 논의중이라 추후 작업진행하겠습니다)

3. 미션 추가 API 수정
미션 추가시 초기 값 설정과 유효성 검사 완료했습니다.
null 값에 대한 크러쉬가 일어나는 현상을 수정했습니다.



## 📢 TO REVIEWERS
- 컴퓨터 녹을거 같아서 영상은 자고 일어나서 올릴게요

## 📸 SCREENSHOT
<img src="" width="300" />
<!-- video src="" witdh="300"/>-->
