### PR TITLE
[mod/#67] AI 추가뷰 및 알람 뷰 QA 반영

### DIFF
--- a/app/src/main/java/com/kiero/presentation/parent/alarm/navigation/ParentAlarmNavigation.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/alarm/navigation/ParentAlarmNavigation.kt
@@ -17,11 +17,13 @@ fun NavController.navigateToAlarm(
 fun NavGraphBuilder.parentAlarmNavGraph(
     paddingValues: PaddingValues,
     navigateUp: () -> Unit,
+    navigateToSelection: () -> Unit,
 ) {
     composable<Alarm> {
         ParentAlarmRoute(
             paddingValues = paddingValues,
-            navigateUp = navigateUp
+            navigateUp = navigateUp,
+            navigateToSelection = navigateToSelection
         )
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/alarm/screen/ParentAlarmScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/alarm/screen/ParentAlarmScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -38,6 +39,8 @@ import com.kiero.core.designsystem.component.dialog.action.KieroCancelAction
 import com.kiero.core.designsystem.component.dialog.action.KieroConfirmAction
 import com.kiero.core.designsystem.component.indicator.KieroLoadingIndicator
 import com.kiero.core.designsystem.theme.KieroTheme
+import com.kiero.core.trigger.LocalRefreshState
+import com.kiero.presentation.main.navigation.ParentMainTab
 import com.kiero.presentation.parent.alarm.component.ParentAlarmCard
 import com.kiero.presentation.parent.alarm.component.ParentAlarmDateHeader
 import com.kiero.presentation.parent.alarm.model.ParentAlarmUiModel
@@ -46,6 +49,7 @@ import com.kiero.presentation.parent.alarm.viewmodel.ParentAlarmViewModel
 import com.kiero.presentation.parent.component.ParentUserSection
 import com.kiero.presentation.signup.parent.state.ParentSignUpSideEffect
 import com.kiero.presentation.signup.parent.state.ParentSignUpState
+import kotlinx.coroutines.launch
 
 
 @Composable
@@ -54,16 +58,22 @@ fun ParentAlarmRoute(
     navigateUp: () -> Unit,
     navigateToSelection: () -> Unit,
     viewModel: ParentAlarmViewModel = hiltViewModel(),
-    isTabReselected: Boolean = false
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val authState by viewModel.authState.collectAsStateWithLifecycle()
     val listState = rememberLazyListState()
 
-    LaunchedEffect(isTabReselected) {
-        if (isTabReselected) {
-            listState.animateScrollToItem(0)
-            viewModel.refresh()
+    val refreshState = LocalRefreshState.current
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(Unit) {
+        refreshState.refreshEvent.collect { tab ->
+            if (tab == ParentMainTab.ALARM) {
+                scope.launch {
+                    listState.animateScrollToItem(0)
+                }
+                viewModel.refresh()
+            }
         }
     }
 

--- a/app/src/main/java/com/kiero/presentation/parent/alarm/screen/ParentAlarmScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/alarm/screen/ParentAlarmScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -14,47 +13,51 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kiero.R
+import com.kiero.core.common.extension.collectSideEffect
+import com.kiero.core.designsystem.component.dialog.KieroDialog
+import com.kiero.core.designsystem.component.dialog.action.KieroCancelAction
+import com.kiero.core.designsystem.component.dialog.action.KieroConfirmAction
+import com.kiero.core.designsystem.component.indicator.KieroLoadingIndicator
 import com.kiero.core.designsystem.theme.KieroTheme
 import com.kiero.presentation.parent.alarm.component.ParentAlarmCard
 import com.kiero.presentation.parent.alarm.component.ParentAlarmDateHeader
 import com.kiero.presentation.parent.alarm.model.ParentAlarmUiModel
 import com.kiero.presentation.parent.alarm.state.AlarmFeedState
 import com.kiero.presentation.parent.alarm.viewmodel.ParentAlarmViewModel
+import com.kiero.presentation.parent.component.ParentUserSection
+import com.kiero.presentation.signup.parent.state.ParentSignUpSideEffect
+import com.kiero.presentation.signup.parent.state.ParentSignUpState
 
 
 @Composable
 fun ParentAlarmRoute(
     paddingValues: PaddingValues,
     navigateUp: () -> Unit,
+    navigateToSelection: () -> Unit,
     viewModel: ParentAlarmViewModel = hiltViewModel(),
     isTabReselected: Boolean = false
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val authState by viewModel.authState.collectAsStateWithLifecycle()
     val listState = rememberLazyListState()
 
     LaunchedEffect(isTabReselected) {
@@ -64,19 +67,54 @@ fun ParentAlarmRoute(
         }
     }
 
-    ParentAlarmScreen(
-        state = state,
-        onExpandClick = viewModel::toggleExpand,
-        listState = listState,
-        paddingValues = paddingValues,
-        modifier = Modifier.fillMaxSize()
-    )
+    viewModel.sideEffect.collectSideEffect {
+        when (it) {
+            is ParentSignUpSideEffect.NavigateToSelection -> navigateToSelection()
+            else -> {}
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        ParentAlarmScreen(
+            state = state,
+            authState = authState,
+            onExpandClick = viewModel::toggleExpand,
+            onUserNameClick = viewModel::onProfileClick,
+            listState = listState,
+            paddingValues = paddingValues,
+            modifier = Modifier.fillMaxSize()
+        )
+
+        if (authState.isLogoutDialogVisible) {
+            KieroDialog(
+                title = "로그아웃",
+                subDescription = "로그아웃 하시겠습니까?",
+                onDismiss = viewModel::onLogoutCancel,
+                confirmAction = KieroConfirmAction(
+                    text = "확인",
+                    onClick = viewModel::onLogoutConfirm
+                ),
+                cancelAction = KieroCancelAction(
+                    text = "취소",
+                    onClick = viewModel::onLogoutCancel
+                ),
+                isDisabled = true,
+                content = {}
+            )
+        }
+
+        if (authState.isLoading) {
+            KieroLoadingIndicator()
+        }
+    }
 }
 
 @Composable
 private fun ParentAlarmScreen(
     state: AlarmFeedState,
+    authState: ParentSignUpState,
     onExpandClick: (String) -> Unit,
+    onUserNameClick: () -> Unit,
     listState: LazyListState,
     paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
@@ -86,43 +124,24 @@ private fun ParentAlarmScreen(
             .background(color = KieroTheme.colors.black)
             .padding(paddingValues)
     ) {
-        Row(
+        ParentUserSection(
+            userName = authState.parentInfo.parentName,
+            profileImage = authState.parentInfo.parentProfileImage,
+            onUserNameClick = onUserNameClick,
+            backgroundColor = KieroTheme.colors.black,
             modifier = Modifier
-                .fillMaxWidth()
-                .background(color = KieroTheme.colors.black)
-                .statusBarsPadding()
-                .padding(
-                    top = 25.dp,
-                    bottom = 15.dp,
-                    start = 16.dp,
-                    end = 16.dp
-                ),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.End
-        ) {
-            Text(
-                text = "근영맘",
-                style = KieroTheme.typography.regular.body2,
-                color = KieroTheme.colors.white
-            )
-            Spacer(modifier = Modifier.width(4.dp))
-            Icon(
-                imageVector = ImageVector.vectorResource(id = R.drawable.ic_parent_profile),
-                contentDescription = null,
-                modifier = Modifier.size(32.dp),
-                tint = KieroTheme.colors.gray500
-            )
-        }
+        )
 
         when {
             state.isLoading -> {
-                Box(Modifier.fillMaxSize(),
+                Box(
+                    Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center
                 ) {
                     CircularProgressIndicator(color = KieroTheme.colors.main)
                 }
             }
-            state.alarms.isEmpty() ->{
+            state.alarms.isEmpty() -> {
                 EmptyAlarmView()
             }
             else -> {
@@ -138,12 +157,16 @@ private fun ParentAlarmScreen(
                     )
                 ) {
                     val sortedAlarms = state.alarms
-                        .sortedWith(compareByDescending<ParentAlarmUiModel> { it.date }
-                            .thenByDescending { it.time })
+                        .sortedWith(
+                            compareByDescending<ParentAlarmUiModel> { it.date }
+                                .thenByDescending { it.time }
+                        )
                     val groupedAlarms = sortedAlarms.groupBy { it.date }
 
                     groupedAlarms.forEach { (date, alarmsForDate) ->
-                        item(key = "header_$date") { ParentAlarmDateHeader(date = date) }
+                        item(key = "header_$date") {
+                            ParentAlarmDateHeader(date = date)
+                        }
 
                         items(items = alarmsForDate, key = { it.id }) { alarm ->
                             ParentAlarmCard(
@@ -169,7 +192,10 @@ private fun ParentAlarmScreen(
 @Composable
 private fun EmptyAlarmView() {
     Column(
-        modifier = Modifier.fillMaxWidth().fillMaxHeight().background(KieroTheme.colors.black),
+        modifier = Modifier
+            .fillMaxWidth()
+            .fillMaxHeight()
+            .background(KieroTheme.colors.black),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Spacer(modifier = Modifier.height(175.dp))
@@ -183,7 +209,9 @@ private fun EmptyAlarmView() {
         Image(
             painter = painterResource(id = R.drawable.img_parent_no_alarm),
             contentDescription = null,
-            modifier = Modifier.fillMaxWidth().aspectRatio(360f / 274f),
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(360f / 274f),
             contentScale = ContentScale.FillWidth
         )
     }

--- a/app/src/main/java/com/kiero/presentation/parent/alarm/viewmodel/ParentAlarmViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/alarm/viewmodel/ParentAlarmViewModel.kt
@@ -18,7 +18,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -146,7 +145,6 @@ class ParentAlarmViewModel @Inject constructor(
         viewModelScope.launch {
             sseManager.parentFeedEvents.collect { feedEvent ->
                 Timber.d("📢 새 알림 도착: ${feedEvent.data.eventType}")
-                delay(500)
                 refresh()
             }
         }

--- a/app/src/main/java/com/kiero/presentation/parent/alarm/viewmodel/ParentAlarmViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/alarm/viewmodel/ParentAlarmViewModel.kt
@@ -3,17 +3,29 @@ package com.kiero.presentation.parent.alarm.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kiero.core.common.extension.toHandleErrorMessage
+import com.kiero.core.common.util.suspendRunCatching
+import com.kiero.core.localstorage.TokenManager
 import com.kiero.core.localstorage.info.UserInfoManager
 import com.kiero.data.alarm.repository.AlarmRepository
+import com.kiero.data.auth.repository.AuthRepository
+import com.kiero.data.demo.repository.DemoRepository
 import com.kiero.data.sse.manager.SseManager
 import com.kiero.presentation.parent.alarm.model.toUiModel
 import com.kiero.presentation.parent.alarm.state.AlarmFeedState
+import com.kiero.presentation.signup.parent.state.ParentSignUpSideEffect
+import com.kiero.presentation.signup.parent.state.ParentSignUpState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -25,12 +37,20 @@ import javax.inject.Inject
 class ParentAlarmViewModel @Inject constructor(
     private val repository: AlarmRepository,
     private val userInfoManager: UserInfoManager,
-    private val sseManager: SseManager
+    private val sseManager: SseManager,
+    private val authRepository: AuthRepository,
+    private val tokenManager: TokenManager,
+    private val demoRepository: DemoRepository
 ) : ViewModel() {
 
     private val _localState = MutableStateFlow(LocalState())
     private var childId: Long? = null
 
+    private val _authState = MutableStateFlow(ParentSignUpState())
+    val authState: StateFlow<ParentSignUpState> = _authState.asStateFlow()
+
+    private val _sideEffect = MutableSharedFlow<ParentSignUpSideEffect>()
+    val sideEffect: SharedFlow<ParentSignUpSideEffect> = _sideEffect.asSharedFlow()
 
     val state: StateFlow<AlarmFeedState> = combine(
         _localState,
@@ -56,16 +76,77 @@ class ParentAlarmViewModel @Inject constructor(
     )
 
     init {
+        initFetchParentInfo()
         loadChildIdAndAlarms()
         collectFeedEvents()
+    }
+
+    fun initFetchParentInfo() {
+        viewModelScope.launch {
+            val parentInfo = userInfoManager.getParentInfo()!!
+
+            _authState.update { currentState ->
+                currentState.copy(
+                    parentInfo = currentState.parentInfo.copy(
+                        parentName = parentInfo.name,
+                        parentProfileImage = parentInfo.profileImage
+                    )
+                )
+            }
+        }
+    }
+
+    fun onProfileClick() {
+        _authState.update {
+            it.copy(isLogoutDialogVisible = true)
+        }
+    }
+
+    fun onLogoutCancel() {
+        _authState.update {
+            it.copy(isLogoutDialogVisible = false)
+        }
+    }
+
+    fun onLogoutConfirm() {
+        _authState.update {
+            it.copy(
+                isLogoutDialogVisible = false,
+                isLoading = true
+            )
+        }
+
+        logOut()
+    }
+
+    fun logOut() {
+        Timber.e("로그아웃 되었습니다")
+        viewModelScope.launch {
+            val logoutDeferred = async {
+                suspendRunCatching { authRepository.postLogout() }
+            }
+            val demoDeferred = async {
+                suspendRunCatching { demoRepository.deleteDemo() }
+            }
+            val tokenDeferred = async {
+                suspendRunCatching { tokenManager.clearTokens() }
+            }
+
+            awaitAll(logoutDeferred, demoDeferred, tokenDeferred)
+
+            _authState.update {
+                it.copy(isLoading = false)
+            }
+
+            _sideEffect.emit(ParentSignUpSideEffect.NavigateToSelection)
+        }
     }
 
     private fun collectFeedEvents() {
         viewModelScope.launch {
             sseManager.parentFeedEvents.collect { feedEvent ->
                 Timber.d("📢 새 알림 도착: ${feedEvent.data.eventType}")
-                // ✅ 서버 DB 동기화를 위해 약간 지연
-                delay(500) // 0.5초 대기
+                delay(500)
                 refresh()
             }
         }

--- a/app/src/main/java/com/kiero/presentation/parent/component/ParentUserSection.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/component/ParentUserSection.kt
@@ -34,13 +34,12 @@ fun ParentUserSection(
     profileImage: String,
     onUserNameClick: () -> Unit,
     modifier: Modifier = Modifier,
+    backgroundColor: Color = KieroTheme.colors.gray900
 ) {
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .background(
-                color = KieroTheme.colors.gray900
-            )
+            .background(color = backgroundColor)
     ) {
         Spacer(modifier = Modifier.height(33.dp))
 

--- a/app/src/main/java/com/kiero/presentation/parent/navigation/ParentNavigation.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/navigation/ParentNavigation.kt
@@ -75,6 +75,7 @@ fun NavGraphBuilder.parentNavGraph(
         parentAlarmNavGraph(
             paddingValues = paddingValues,
             navigateUp = navigateUp,
+            navigateToSelection = navigateToSelection
         )
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/ParentScheduleScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/ParentScheduleScreen.kt
@@ -57,6 +57,7 @@ fun ParentScheduleRoute(
     val uiState by viewModel.state.collectAsStateWithLifecycle()
     val authState by viewModel.authstate.collectAsStateWithLifecycle()
     val selectedTabIndex by viewModel.selectedTabIndex.collectAsStateWithLifecycle()
+    val childId by viewModel.childId.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         viewModel.fetchSchedule()
@@ -84,6 +85,7 @@ fun ParentScheduleRoute(
                     paddingValues = paddingValues,
                     state = authState,
                     scheduleState = state.data,
+                    childId = childId,
                     selectedTabIndex = selectedTabIndex,
                     onTabSelected = viewModel::updateTabIndex,
                     onDateChange = viewModel::onDateChange,
@@ -108,6 +110,7 @@ fun ParentScheduleRoute(
                 ParentScheduleScreen(
                     paddingValues = paddingValues,
                     state = authState,
+                    childId = childId,
                     scheduleState = ParentScheduleState(),
                     selectedTabIndex = selectedTabIndex,
                     onTabSelected = viewModel::updateTabIndex,
@@ -154,6 +157,7 @@ private fun ParentScheduleScreen(
     paddingValues: PaddingValues,
     state: ParentSignUpState,
     scheduleState: ParentScheduleState,
+    childId: Long?,
     navigateToAutoMissionAdd: (Long) -> Unit,
     selectedTabIndex: Int,
     modifier: Modifier = Modifier,
@@ -229,7 +233,7 @@ private fun ParentScheduleScreen(
                 onExpandedChange = { isMissionFabExpanded = it },
                 onMissionAdd = navigateToMissionAdd,
                 onMissionRecommend = {
-                    navigateToAutoMissionAdd(10) // 임시 ChildID
+                    childId?.let { navigateToAutoMissionAdd(it) }
                 },
                 modifier = Modifier
                     .align(Alignment.BottomEnd)

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/ParentAutoAddScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/ParentAutoAddScreen.kt
@@ -56,11 +56,7 @@ fun ParentAutoAddRoute(
     viewModel.sideEffect.collectSideEffect { effect ->
         when (effect) {
             is AutoMissionSideEffect.ShowToast -> {
-                globalUiEventHolder.showSnackbar(
-                    SnackbarState(
-                        message = effect.message
-                    )
-                )
+                // ParentAutoResultRoute에서 처리
             }
 
             is AutoMissionSideEffect.NavigateBack -> {
@@ -159,7 +155,7 @@ fun ParentAutoAddScreen(
             KieroButtonMedium(
                 text = "분석하고 미션 추가하기",
                 onClick = onAnalyzeClick,
-                isEnabled = state.isAnalyzeEnabled,  // ✅ Computed property
+                isEnabled = state.isAnalyzeEnabled,
                 containerColor = KieroTheme.colors.main,
                 contentColor = KieroTheme.colors.black,
                 modifier = Modifier.padding(horizontal = 16.dp)

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/ParentAutoResultScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/ParentAutoResultScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
@@ -228,58 +227,6 @@ private fun ParentAutoResultScreenPreview() {
                 ),
                 currentIndex = 0,
                 selectedDate = LocalDate.now().plusDays(1)
-            ),
-            onMissionNameChange = {},
-            onDateSelected = {},
-            onRewardClick = {},
-            onIndexChange = {},
-            onSaveClick = {},
-            onCancelClick = {},
-            onShowDatePicker = {},
-            onDismissDatePicker = {},
-            awardTextFieldState = awardTextFieldState,
-            paddingValues = PaddingValues(0.dp),
-            snackbarHostState = snackbarHostState
-        )
-    }
-}
-
-@Preview(
-    name = "Multiple Missions",
-    showBackground = true,
-    backgroundColor = 0xFF000000,
-    device = "spec:width=360dp,height=800dp,dpi=420"
-)
-@Composable
-private fun ParentAutoResultScreenMultipleMissionsPreview() {
-    val snackbarHostState = remember { SnackbarHostState() }
-    val awardTextFieldState = rememberTextFieldState("20")
-
-    KieroTheme {
-        ParentAutoResultScreen(
-            state = AutoMissionState(
-                missions = listOf(
-                    MissionUiModel(
-                        name = "수학 숙제하기",
-                        dueAt = LocalDate.now().plusDays(1),
-                        reward = 20,
-                        isCompleted = false
-                    ),
-                    MissionUiModel(
-                        name = "체육복 챙기기",
-                        dueAt = LocalDate.now().plusDays(2),
-                        reward = 30,
-                        isCompleted = false
-                    ),
-                    MissionUiModel(
-                        name = "일기 쓰기",
-                        dueAt = LocalDate.now().plusDays(1),
-                        reward = 50,
-                        isCompleted = false
-                    )
-                ),
-                currentIndex = 1,
-                selectedDate = LocalDate.now().plusDays(2)
             ),
             onMissionNameChange = {},
             onDateSelected = {},

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/ParentAutoResultScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/ParentAutoResultScreen.kt
@@ -1,6 +1,7 @@
 package com.kiero.presentation.parent.schedule.mission.auto
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -11,13 +12,17 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material3.SnackbarHost
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.kiero.R
@@ -25,13 +30,14 @@ import com.kiero.core.designsystem.component.KieroTopbar
 import com.kiero.core.designsystem.component.button.KieroButtonMedium
 import com.kiero.core.designsystem.theme.KieroTheme
 import com.kiero.presentation.parent.schedule.mission.auto.component.ParentAutoMissionEditForm
-import com.kiero.presentation.parent.schedule.mission.auto.component.ParentLocalKieroSnackbar
 import com.kiero.presentation.parent.schedule.mission.auto.component.ParentMissionNavigator
+import com.kiero.presentation.parent.schedule.mission.auto.model.MissionUiModel
+import com.kiero.presentation.parent.schedule.mission.auto.state.AutoMissionSideEffect
 import com.kiero.presentation.parent.schedule.mission.auto.state.AutoMissionState
 import com.kiero.presentation.parent.schedule.mission.auto.viewmodel.AutoMissionViewModel
 import com.kiero.presentation.parent.schedule.mission.component.datepicker.component.CalendarBottomSheet
+import kotlinx.coroutines.launch
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 
 
 @Composable
@@ -41,10 +47,25 @@ fun ParentAutoResultRoute(
     viewModel: AutoMissionViewModel = hiltViewModel(),
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
 
     LaunchedEffect(state.missions) {
         if (state.missions.isNotEmpty() && state.currentIndex == 0) {
             viewModel.updateCurrentIndex(0)
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is AutoMissionSideEffect.ShowToast -> {
+                    scope.launch {
+                        snackbarHostState.currentSnackbarData?.dismiss()
+                        snackbarHostState.showSnackbar(effect.message)
+                    }
+                }
+                else -> {}
+            }
         }
     }
     ParentAutoResultScreen(
@@ -54,7 +75,7 @@ fun ParentAutoResultRoute(
         onRewardClick = viewModel::onAwardClick,
         onIndexChange = viewModel::updateCurrentIndex,
         onSaveClick = { viewModel.saveAllMissions() },
-        onCancelClick = viewModel::handleCancel,
+        onCancelClick = viewModel::backToInputScreen,
         onShowDatePicker = viewModel::showDatePicker,
         onDismissDatePicker = viewModel::dismissDatePicker,
         awardTextFieldState = viewModel.awardTextFieldState,
@@ -79,6 +100,9 @@ fun ParentAutoResultScreen(
     snackbarHostState: SnackbarHostState,
     modifier: Modifier = Modifier,
 ) {
+
+    val focusManager = LocalFocusManager.current
+
     val pagerState = rememberPagerState(
         initialPage = state.currentIndex,
         pageCount = { state.missions.size }
@@ -100,7 +124,12 @@ fun ParentAutoResultScreen(
         modifier = modifier
             .fillMaxSize()
             .background(KieroTheme.colors.black)
-            .padding(paddingValues),
+            .padding(paddingValues)
+            .pointerInput(Unit) {
+                detectTapGestures(onTap = {
+                    focusManager.clearFocus()
+                })
+            },
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Spacer(modifier = Modifier.height(44.dp))
@@ -122,38 +151,24 @@ fun ParentAutoResultScreen(
 
         Spacer(modifier = Modifier.height(20.dp))
 
-        Box(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-        ) {
-            HorizontalPager(
-                state = pagerState,
-                modifier = Modifier.fillMaxSize()
-            ) { page ->
-                state.missions.getOrNull(page)?.let { mission ->
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.weight(1f)
+        ) { page ->
+            state.missions.getOrNull(page)?.let { mission ->
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp)
+                ) {
                     ParentAutoMissionEditForm(
                         mission = mission,
                         selectedDate = state.selectedDate,
                         onMissionNameChange = onMissionNameChange,
                         onDateClick = onShowDatePicker,
                         onRewardClick = onRewardClick,
-                        awardTextFieldState = awardTextFieldState
-                    )
-                }
-            }
-
-            Box(
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .fillMaxWidth()
-                    .padding(start = 16.dp, end = 16.dp, bottom = 31.dp)
-            ) {
-                SnackbarHost(hostState = snackbarHostState) { data ->
-                    ParentLocalKieroSnackbar(
-                        message = data.visuals.message,
-                        modifier = Modifier.fillMaxWidth()
+                        awardTextFieldState = awardTextFieldState,
+                        snackbarHostState = snackbarHostState  // 추가
                     )
                 }
             }
@@ -178,5 +193,105 @@ fun ParentAutoResultScreen(
                 onDateSelected = onDateSelected
             )
         }
+    }
+}
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xFF000000,
+    device = "spec:width=360dp,height=800dp,dpi=420"
+)
+@Composable
+private fun ParentAutoResultScreenPreview() {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val awardTextFieldState = rememberTextFieldState("20")
+
+    LaunchedEffect(Unit) {
+        snackbarHostState.showSnackbar("보상은 500개까지 설정할 수 있어요.")
+    }
+
+    KieroTheme {
+        ParentAutoResultScreen(
+            state = AutoMissionState(
+                missions = listOf(
+                    MissionUiModel(
+                        name = "수학 숙제하기",
+                        dueAt = LocalDate.now().plusDays(1),
+                        reward = 20,
+                        isCompleted = false
+                    ),
+                    MissionUiModel(
+                        name = "체육복 챙기기",
+                        dueAt = LocalDate.now().plusDays(2),
+                        reward = 30,
+                        isCompleted = false
+                    )
+                ),
+                currentIndex = 0,
+                selectedDate = LocalDate.now().plusDays(1)
+            ),
+            onMissionNameChange = {},
+            onDateSelected = {},
+            onRewardClick = {},
+            onIndexChange = {},
+            onSaveClick = {},
+            onCancelClick = {},
+            onShowDatePicker = {},
+            onDismissDatePicker = {},
+            awardTextFieldState = awardTextFieldState,
+            paddingValues = PaddingValues(0.dp),
+            snackbarHostState = snackbarHostState
+        )
+    }
+}
+
+@Preview(
+    name = "Multiple Missions",
+    showBackground = true,
+    backgroundColor = 0xFF000000,
+    device = "spec:width=360dp,height=800dp,dpi=420"
+)
+@Composable
+private fun ParentAutoResultScreenMultipleMissionsPreview() {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val awardTextFieldState = rememberTextFieldState("20")
+
+    KieroTheme {
+        ParentAutoResultScreen(
+            state = AutoMissionState(
+                missions = listOf(
+                    MissionUiModel(
+                        name = "수학 숙제하기",
+                        dueAt = LocalDate.now().plusDays(1),
+                        reward = 20,
+                        isCompleted = false
+                    ),
+                    MissionUiModel(
+                        name = "체육복 챙기기",
+                        dueAt = LocalDate.now().plusDays(2),
+                        reward = 30,
+                        isCompleted = false
+                    ),
+                    MissionUiModel(
+                        name = "일기 쓰기",
+                        dueAt = LocalDate.now().plusDays(1),
+                        reward = 50,
+                        isCompleted = false
+                    )
+                ),
+                currentIndex = 1,
+                selectedDate = LocalDate.now().plusDays(2)
+            ),
+            onMissionNameChange = {},
+            onDateSelected = {},
+            onRewardClick = {},
+            onIndexChange = {},
+            onSaveClick = {},
+            onCancelClick = {},
+            onShowDatePicker = {},
+            onDismissDatePicker = {},
+            awardTextFieldState = awardTextFieldState,
+            paddingValues = PaddingValues(0.dp),
+            snackbarHostState = snackbarHostState
+        )
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/component/ParentAutoInputField.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/component/ParentAutoInputField.kt
@@ -1,8 +1,6 @@
 package com.kiero.presentation.parent.schedule.mission.auto.component
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -10,12 +8,17 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import com.kiero.core.designsystem.theme.KieroTheme
 
@@ -24,6 +27,7 @@ fun ParentAutoInputField(
     text: String,
     onTextChange: (String) -> Unit,
     modifier: Modifier = Modifier,
+    onSelectionChange: ((TextRange) -> Unit)? = null,
     placeholder: String = "알림장 내용을 입력하세요.",
     maxLength: Int = 1000,
     maxLines: Int = Int.MAX_VALUE,
@@ -32,12 +36,21 @@ fun ParentAutoInputField(
     textColor: Color = KieroTheme.colors.gray400
 ) {
     val focusManager = LocalFocusManager.current
+    var selection by remember { mutableStateOf(TextRange(text.length)) }
 
+    val textFieldValue = TextFieldValue(
+        text = text,
+        selection = selection
+    )
     TextField(
-        value = text,
-        onValueChange = { newText ->
-            if (newText.length <= maxLength) {
-                onTextChange(newText)
+        value = textFieldValue, // String 대신 TextFieldValue 사용
+        onValueChange = { newTextFieldValue ->
+            if (newTextFieldValue.text.length <= maxLength) {
+                if (text != newTextFieldValue.text) {
+                    onTextChange(newTextFieldValue.text)
+                }
+                selection = newTextFieldValue.selection
+                onSelectionChange?.invoke(newTextFieldValue.selection)
             }
         },
         placeholder = {
@@ -72,58 +85,4 @@ fun ParentAutoInputField(
             }
         )
     )
-}
-
-@Preview
-@Composable
-private fun ParentAutoInputFieldPreview() {
-    KieroTheme {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-        ) {
-            ParentAutoInputField(
-                text = "",
-                onTextChange = {}
-            )
-        }
-    }
-}
-
-@Preview
-@Composable
-private fun ParentAutoInputFieldWithTextPreview() {
-    KieroTheme {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-        ) {
-            ParentAutoInputField(
-                text = "내일은 독서록을 가져오세요. 수학 익힘책 30쪽까지 풀어오세요.",
-                onTextChange = {}
-            )
-        }
-    }
-}
-
-@Preview
-@Composable
-private fun ParentAutoInputFieldMissionNamePreview() {
-    KieroTheme {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-        ) {
-            ParentAutoInputField(
-                text = "독서록 챙기기",
-                onTextChange = {},
-                placeholder = "미션 이름을 입력해주세요.",
-                maxLength = 15,
-                singleLine = true
-            )
-        }
-    }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/component/ParentAutoMissionAwardSelect.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/component/ParentAutoMissionAwardSelect.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kiero.core.common.extension.noRippleClickable
 import com.kiero.core.designsystem.theme.KieroTheme
-import com.kiero.presentation.parent.schedule.mission.component.missionadd.MissionTextField
 import com.kiero.presentation.parent.schedule.mission.component.model.MissionAwardDefaults
 
 @Composable
@@ -36,13 +35,10 @@ fun ParentAutoMissionAwardSelect(
     ) {
         MissionAwardDefaults.PRESET_VALUES.forEachIndexed { index, presetValue ->
             if (index == 2) {
-                MissionTextField(
+                ParentAutoMissionTextField(
                     state = textFieldState,
-                    placeholder = textFieldState.text.toString().ifEmpty {
-                        MissionAwardDefaults.DEFAULT_AWARD.toString()
-                    },
-                    modifier = Modifier
-                        .weight(0.5f)
+                    placeholder = "",
+                    modifier = Modifier.weight(0.5f)
                 )
             }
 

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/component/ParentAutoMissionEditForm.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/component/ParentAutoMissionEditForm.kt
@@ -1,17 +1,21 @@
 package com.kiero.presentation.parent.schedule.mission.auto.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kiero.core.designsystem.theme.KieroTheme
 import com.kiero.presentation.parent.schedule.mission.auto.model.MissionUiModel
@@ -27,67 +31,66 @@ fun ParentAutoMissionEditForm(
     onDateClick: () -> Unit,
     onRewardClick: (Int) -> Unit,
     awardTextFieldState: TextFieldState,
+    snackbarHostState: SnackbarHostState,
     modifier: Modifier = Modifier
 ) {
-
     val dateToDisplay = remember(selectedDate, mission.dueAt) {
         val targetDate = selectedDate ?: mission.dueAt
         targetDate.format(DateTimeFormatter.ofPattern("yyyy.MM.dd.(E)", Locale.KOREA))
     }
-    Column(
+
+    Box(
         modifier = modifier
             .fillMaxSize()
             .background(
                 color = KieroTheme.colors.gray900,
                 shape = RoundedCornerShape(15.dp)
             )
-            .padding(
+    ) {
+        Column(
+            modifier = Modifier.padding(
                 top = 12.dp,
                 start = 14.dp,
                 end = 14.dp,
                 bottom = 12.dp
-            ),
-    ) {
-        ParentAutoInputField(
-            text = mission.name,
-            onTextChange = onMissionNameChange,
-            placeholder = "미션 이름을 입력해주세요.",
-            maxLength = 15,
-            singleLine = true
-        )
+            )
+        ) {
+            ParentAutoInputField(
+                text = mission.name,
+                onTextChange = onMissionNameChange,
+                placeholder = "미션 이름을 입력해주세요.",
+                maxLength = 15,
+                singleLine = true
+            )
 
-        ParentAutoMissionCalendar(
-            dateText = dateToDisplay,
-            onDateClick = onDateClick
-        )
+            ParentAutoMissionCalendar(
+                dateText = dateToDisplay,
+                onDateClick = onDateClick
+            )
 
-        ParentAutoMissionAwardInfo()
+            ParentAutoMissionAwardInfo()
 
-        Spacer(Modifier.height(12.dp))
+            Spacer(Modifier.height(12.dp))
 
-        ParentAutoMissionAwardSelect(
-            textFieldState = awardTextFieldState,
-            onAwardClick = onRewardClick
-        )
-    }
-}
+            ParentAutoMissionAwardSelect(
+                textFieldState = awardTextFieldState,
+                onAwardClick = onRewardClick
+            )
+        }
 
-@Preview
-@Composable
-private fun ParentAutoMissionEditFormPreview() {
-    KieroTheme {
-        ParentAutoMissionEditForm(
-            mission = MissionUiModel(
-                name = "수학 숙제하기",
-                dueAt = LocalDate.now().plusDays(1),
-                reward = 20
-            ),
-            selectedDate = LocalDate.now(),
-            onMissionNameChange = {},
-            onDateClick = {},
-            onRewardClick = {},
-            awardTextFieldState = TextFieldState(),
-            modifier = Modifier.padding(16.dp)
-        )
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .padding(horizontal = 25.dp)
+                .padding(bottom = 36.dp)
+        ) {
+            SnackbarHost(hostState = snackbarHostState) { data ->
+                ParentLocalKieroSnackbar(
+                    message = data.visuals.message,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/component/ParentAutoMissionTextField.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/component/ParentAutoMissionTextField.kt
@@ -1,0 +1,135 @@
+package com.kiero.presentation.parent.schedule.mission.auto.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.KeyboardActionHandler
+import androidx.compose.foundation.text.input.OutputTransformation
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.maxLength
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.kiero.core.designsystem.theme.KieroTheme
+
+@Composable
+fun ParentAutoMissionTextField(
+    state: TextFieldState,
+    placeholder: String,
+    modifier: Modifier = Modifier,
+    onFocusLost: () -> Unit = {},
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    inputTransformation: InputTransformation? = null,
+    outputTransformation: OutputTransformation? = null,
+    keyboardOptions: KeyboardOptions = KeyboardOptions(
+        keyboardType = KeyboardType.Number,
+        imeAction = ImeAction.Done
+    ),
+    onKeyboardAction: KeyboardActionHandler? = null,
+    lineLimits: TextFieldLineLimits = TextFieldLineLimits.SingleLine,
+    textColor: Color = KieroTheme.colors.white,
+    maxLength: Int = 3,
+) {
+    val focusManager = LocalFocusManager.current
+    val interactionSource = remember { MutableInteractionSource() }
+    val borderColor = KieroTheme.colors.gray600
+
+    val defaultKeyboardAction = KeyboardActionHandler {
+        if (state.text.isEmpty()) {
+            state.edit {
+                replace(0, 0, "20")
+            }
+        }
+        onFocusLost()
+        focusManager.clearFocus()
+    }
+
+    BasicTextField(
+        state = state,
+        enabled = enabled,
+        readOnly = readOnly,
+        inputTransformation = inputTransformation ?: InputTransformation.maxLength(maxLength),
+        outputTransformation = outputTransformation,
+        keyboardOptions = keyboardOptions,
+        onKeyboardAction = onKeyboardAction ?: defaultKeyboardAction,
+        lineLimits = lineLimits,
+        textStyle = KieroTheme.typography.semiBold.title3.copy(
+            color = textColor,
+            textAlign = TextAlign.Center
+        ),
+        cursorBrush = SolidColor(KieroTheme.colors.white),
+        interactionSource = interactionSource,
+        modifier = modifier.wrapContentWidth(),
+        decorator = { innerTextField ->
+            Box(
+                modifier = Modifier
+                    .wrapContentWidth()
+                    .background(color = Color.Transparent)
+                    .drawBehind {
+                        val strokeWidth = 1.dp.toPx()
+                        val y = size.height - strokeWidth / 2
+                        drawLine(
+                            color = borderColor,
+                            start = Offset(0f, y),
+                            end = Offset(size.width, y),
+                            strokeWidth = strokeWidth
+                        )
+                    }
+                    .padding(horizontal = 8.dp, vertical = 8.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                if (state.text.isEmpty()) {
+                    Text(
+                        text = placeholder,
+                        style = KieroTheme.typography.semiBold.title3,
+                        color = KieroTheme.colors.white,
+                        textAlign = TextAlign.Center
+                    )
+                }
+                innerTextField()
+            }
+        }
+    )
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF232428)
+@Composable
+private fun MissionTextFieldPreviewDefault() {
+    KieroTheme {
+        ParentAutoMissionTextField(
+            state = rememberTextFieldState(),
+            placeholder = "20",
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF232428)
+@Composable
+private fun MissionTextFieldPreviewWithText() {
+    KieroTheme {
+        ParentAutoMissionTextField(
+            state = rememberTextFieldState("50"),
+            placeholder = "20",
+        )
+    }
+}

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/component/ScrollableAutoInputField.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/component/ScrollableAutoInputField.kt
@@ -1,24 +1,35 @@
 package com.kiero.presentation.parent.schedule.mission.auto.component
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.isImeVisible
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.unit.dp
 import com.kiero.core.designsystem.theme.KieroTheme
 import kotlinx.coroutines.delay
 
-
+@OptIn(ExperimentalLayoutApi::class, ExperimentalFoundationApi::class)
 @Composable
 fun ScrollableAutoInputField(
     text: String,
@@ -28,24 +39,43 @@ fun ScrollableAutoInputField(
     maxLength: Int = 1000,
 ) {
     val scrollState = rememberScrollState()
+    val isFocused = remember { mutableStateOf(false) }
+    val isImeVisible = WindowInsets.isImeVisible
+    var currentSelection by remember { mutableStateOf(TextRange(text.length)) }
     val previousLength = remember { mutableIntStateOf(text.length) }
+    val shouldScrollToBottom = remember { mutableStateOf(false) }
 
     LaunchedEffect(text) {
         val lengthDiff = text.length - previousLength.intValue
         previousLength.intValue = text.length
-
         if (lengthDiff > 5) {
+            shouldScrollToBottom.value = true
+        }
+    }
+
+    LaunchedEffect(shouldScrollToBottom.value) {
+        if (shouldScrollToBottom.value) {
             delay(100)
             scrollState.animateScrollTo(scrollState.maxValue)
+            shouldScrollToBottom.value = false
+        }
+    }
+
+    LaunchedEffect(isImeVisible, isFocused.value) {
+        if (isImeVisible && isFocused.value) {
+            delay(350)
+            val isCursorAtBottom = currentSelection.start == text.length
+
+            if (scrollState.value > 0 && isCursorAtBottom) {
+                scrollState.animateScrollTo(scrollState.maxValue)
+            }
         }
     }
 
     BoxWithConstraints(
-        modifier = modifier
-            .fillMaxSize()
+        modifier = modifier.fillMaxSize()
     ) {
         val minHeight = maxHeight
-
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -54,6 +84,9 @@ fun ScrollableAutoInputField(
             ParentAutoInputField(
                 text = text,
                 onTextChange = onTextChange,
+                onSelectionChange = { range ->
+                    currentSelection = range
+                },
                 placeholder = placeholder,
                 maxLength = maxLength,
                 maxLines = Int.MAX_VALUE,
@@ -63,6 +96,9 @@ fun ScrollableAutoInputField(
                 modifier = Modifier
                     .fillMaxWidth()
                     .heightIn(min = minHeight)
+                    .onFocusChanged { focusState ->
+                        isFocused.value = focusState.isFocused
+                    }
             )
 
             Spacer(Modifier.height(65.dp))

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/viewmodel/AutoMissionViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/viewmodel/AutoMissionViewModel.kt
@@ -40,7 +40,7 @@ class AutoMissionViewModel @Inject constructor(
 
     val sideEffect: SharedFlow<AutoMissionSideEffect> = _sideEffect.asSharedFlow()
 
-    val awardTextFieldState = TextFieldState()
+    val awardTextFieldState = TextFieldState(initialText = "20")
 
     init {
         observeAwardTextFieldChanges()
@@ -236,6 +236,16 @@ class AutoMissionViewModel @Inject constructor(
         }
     }
 
+    fun backToInputScreen() {
+        _state.update {
+            it.copy(
+                missions = emptyList(),
+                currentIndex = 0,
+                hasViewedLastPage = false
+            )
+        }
+    }
+
     fun handleCancel() {
         viewModelScope.launch {
             _sideEffect.emit(AutoMissionSideEffect.NavigateBack)
@@ -258,21 +268,45 @@ class AutoMissionViewModel @Inject constructor(
         viewModelScope.launch {
             snapshotFlow { awardTextFieldState.text.toString() }
                 .collect { text ->
+                    if (text.isEmpty()) {
+                        return@collect
+                    }
                     val value = text.toIntOrNull() ?: return@collect
                     val currentState = _state.value
 
-                    if (value in 1..500 && value != currentState.currentReward) {
-                        _state.update { state ->
-                            val updatedMissions = state.missions.toMutableList().apply {
-                                val index = state.currentIndex
-                                if (index in indices) {
-                                    this[index] = this[index].copy(reward = value)
-                                }
+                    when {
+                        value > 500 -> {
+                            awardTextFieldState.edit {
+                                replace(0, length, "500")
                             }
-                            state.copy(missions = updatedMissions)
+                            _sideEffect.emit(
+                                AutoMissionSideEffect.ShowToast("최대 보상은 500개입니다.")
+                            )
+                            updateMissionReward(500)
+                        }
+                        value < 1 -> {
+                            awardTextFieldState.edit {
+                                replace(0, length, "1")
+                            }
+                            updateMissionReward(1)
+                        }
+                        value != currentState.currentReward -> {
+                            updateMissionReward(value)
                         }
                     }
                 }
+        }
+    }
+
+    private fun updateMissionReward(value: Int) {
+        _state.update { state ->
+            val updatedMissions = state.missions.toMutableList().apply {
+                val index = state.currentIndex
+                if (index in indices) {
+                    this[index] = this[index].copy(reward = value)
+                }
+            }
+            state.copy(missions = updatedMissions)
         }
     }
 

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/viewmodel/ParentScheduleViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/viewmodel/ParentScheduleViewModel.kt
@@ -54,6 +54,9 @@ class ParentScheduleViewModel @Inject constructor(
     private val _selectedTabIndex = MutableStateFlow(0)
     val selectedTabIndex: StateFlow<Int> = _selectedTabIndex.asStateFlow()
 
+    private val _childId = MutableStateFlow<Long?>(null)
+    val childId: StateFlow<Long?> = _childId.asStateFlow()
+
     init {
         initFetchParentInfo()
         ensureChildIdAndStartSse()
@@ -76,6 +79,8 @@ class ParentScheduleViewModel @Inject constructor(
                         Timber.e(it, "📌 자녀 목록 조회 실패")
                     }
             }
+
+            _childId.value = childId
 
             Timber.d("📢 SSE 구독 시작")
             sseManager.startParentSubscription()


### PR DESCRIPTION
## ISSUE
- closed #67 

## ❗ WORK DESCRIPTION
- 자동 미션 스낵바 중복 노출 해결: 상위(ParentAutoAddRoute)와 하위(ParentAutoResultRoute)에서 이중으로 처리되던 스낵바 로직을 정리했습니다.

- UI 디자인 수정: 자동 미션 수정 화면의 스낵바 패딩 및 너비를 디자인 가이드에 맞게 수정했습니다.

- 탭 재클릭 기능 구현: 알림(Alarm) 탭 활성화 상태에서 아이콘 재클릭 시 최상단 스크롤 이동 및 데이터 새로고침이 동작하도록 구현했습니다.

## 📢 TO REVIEWERS
SSE도 부모뷰에서 동작하는지 테스트 해봐야합니당 잘되는지..
일단 QA받은거대로 고치긴했는데,, 실제 기기돌리려니까 빌드가 안돼서 실제기기에선 어떻게나올지 모르겠어요ㅜㅜ

## 📸 SCREENSHOT


https://github.com/user-attachments/assets/5ec83570-f22a-4f31-8e1b-9b8396c5d6e8

