### PR TITLE
[fix/#72] 과거 일정 조회시 일정 추가 상단 탑바  fix

### DIFF
--- a/app/src/main/java/com/kiero/presentation/parent/schedule/ParentScheduleScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/ParentScheduleScreen.kt
@@ -182,7 +182,7 @@ private fun ParentScheduleScreen(
                 .padding(paddingValues)
         ) {
             ParentUserSection(
-                userName = state.parentInfo.parentName,
+                userName = state.parentInfo.formattedParentName,
                 profileImage = state.parentInfo.parentProfileImage,
                 onUserNameClick = onUserNameClick,
                 modifier = Modifier

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/ParentScheduleScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/ParentScheduleScreen.kt
@@ -92,7 +92,7 @@ fun ParentScheduleRoute(
                     onResetToToday = viewModel::resetToday,
                     navigateToScheduleAdd = {
                         navigateToScheduleAdd(
-                            state.data.currentDate.toString(),
+                            state.data.navInitialDate,
                             state.data.isFireLit
                         )
                     },

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/ParentMissionScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/ParentMissionScreen.kt
@@ -2,10 +2,11 @@ package com.kiero.presentation.parent.schedule.mission
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -21,10 +22,14 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kiero.R
+import com.kiero.core.common.extension.formatWithDayOfWeek
+import com.kiero.core.common.extension.toRelativeDayFromDate
 import com.kiero.core.designsystem.theme.KieroTheme
 import com.kiero.core.model.UiState
 import com.kiero.core.trigger.LocalRefreshState
 import com.kiero.presentation.main.navigation.ParentMainTab
+import com.kiero.presentation.parent.schedule.mission.component.missionmain.MissionInfo
+import com.kiero.presentation.parent.schedule.mission.component.missionmain.MissionListItem
 import com.kiero.presentation.parent.schedule.mission.state.ParentMissionState
 import com.kiero.presentation.parent.schedule.mission.viewmodel.ParentMissionViewModel
 
@@ -88,16 +93,34 @@ fun ParentMissionScreen(
         modifier = modifier
             .fillMaxSize()
             .background(color = KieroTheme.colors.black),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
         contentPadding = PaddingValues(16.dp)
     ) {
-        items(
-            items = state.kidMissionByDateList.missionsByDate,
-            key = { missionsByDate -> missionsByDate.dueAt }
-        ) { missionsByDate ->
-            MissionDateGroup(
-                missionsByDate = missionsByDate,
-            )
+        state.kidMissionByDateList.missionsByDate.forEach { missionsByDate ->
+
+            stickyHeader(key = missionsByDate.dueAt) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(color = KieroTheme.colors.black)
+                        .padding(vertical = 8.dp)
+                ) {
+                    MissionInfo(
+                        dayOfWeek = missionsByDate.dueAt.toRelativeDayFromDate,
+                        dueAt = missionsByDate.dueAt.formatWithDayOfWeek
+                    )
+                }
+            }
+
+            items(
+                items = missionsByDate.missions,
+            ) { mission ->
+                Box(modifier = Modifier.padding(vertical = 6.dp)) {
+                    MissionListItem(
+                        missionTitle = mission.name,
+                        reward = mission.reward,
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/component/missionmain/MissionListItem.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/component/missionmain/MissionListItem.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -68,6 +69,7 @@ fun MissionInfo(
     dueAt: String,
     modifier: Modifier = Modifier,
     dayOfWeek: String? = null,
+    isVisible: Boolean = true,
 ) {
     val annotateDate = remember(dueAt) {
         buildAnnotatedString {
@@ -86,16 +88,15 @@ fun MissionInfo(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .background(color = Color.Unspecified),
+            .background(color = Color.Unspecified)
+            .alpha(if (isVisible) 1f else 0f),
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        dayOfWeek?.let {
-            Text(
-                text = dayOfWeek,
-                color = KieroTheme.colors.gray300,
-                style = KieroTheme.typography.semiBold.title4
-            )
-        }
+        Text(
+            text = dayOfWeek ?: " ",
+            color = KieroTheme.colors.gray300,
+            style = KieroTheme.typography.semiBold.title4
+        )
 
         Text(
             text = annotateDate,

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/plan/SchedulePlanner.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/plan/SchedulePlanner.kt
@@ -39,7 +39,9 @@ fun ScheduleTimeTable(
         verticalArrangement = Arrangement.spacedBy(11.dp)
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp)
         ) {
             ScheduleTimeColumn()
 
@@ -59,6 +61,10 @@ fun SchedulePlanner(
     val hourHeight = with(density) { 38.dp.roundToPx().toDp() }
     val slotHeight = hourHeight / 4
 
+    val innerPadding = 4.dp
+    val bottomBuffer = 4.dp
+    val totalHeight = (hourHeight * 14) + (innerPadding * 2) + bottomBuffer
+
     val allBlocks = events.flatMap { event ->
         val indices = state.run { event.getIndices() }
 
@@ -70,10 +76,10 @@ fun SchedulePlanner(
     BoxWithConstraints(
         modifier = modifier
             .fillMaxWidth()
-            .height(hourHeight * 15)
+            .height(totalHeight)
             .clip(RoundedCornerShape(10.dp))
             .border(0.3.dp, KieroTheme.colors.gray800, RoundedCornerShape(10.dp))
-            .padding(4.dp)
+            .padding(innerPadding)
     ) {
         val dayWidth = maxWidth / daysCount
         if (events.isEmpty()) {
@@ -115,8 +121,8 @@ fun SchedulePlanner(
                     ScheduleEventBlock(block = block)
                 }
             }
-
         }
+        Spacer(modifier = Modifier.height(14.dp))
     }
 }
 

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/plan/ScheduleTimeColumn.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/component/plan/ScheduleTimeColumn.kt
@@ -36,7 +36,7 @@ fun ScheduleTimeColumn(
             modifier = Modifier
                 .padding(bottom = 27.dp)
         )
-        (9..22).forEach { hour ->
+        (9..21).forEach { hour ->
             Box(
                 modifier = Modifier
                     .height(38.dp)

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/plan/state/PlanScheduleState.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/plan/state/PlanScheduleState.kt
@@ -43,6 +43,18 @@ data class ParentScheduleState(
             return "${targetMonth}월 ${weekNum}주차"
         }
 
+    val navInitialDate: String
+        get() {
+            val today = LocalDate.now()
+            val currentMonday = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+            val viewedMonday = currentDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+
+            return if (viewedMonday.isBefore(currentMonday)) {
+                today.toString()
+            } else {
+                currentDate.toString()
+            }
+        }
     fun ScheduleEvent.getIndices(): List<Int> {
         return if (isRecurring) {
             this.dayOfWeek?.split(",")?.mapNotNull { day ->


### PR DESCRIPTION
## ISSUE
- closed #72 

## ❗ WORK DESCRIPTION
- 과거 날짜의 일정을 조회하는 중 일정 추가로 넘어갔을 때 상단에 현재기준으로 띄어놓기
- 일정 좌측 timecolumn 영역수정
- 일정 하단 영역 수정 및 block 짤림 현상 제거
- 미션 리스트 상단 stickeyHeader 통한 컴포넌트 고정 인터렉션 추가

## 📢 TO REVIEWERS
- 왜 계속 뭐가 추가 되지.

## 📸 SCREENSHOT
<video src="https://github.com/user-attachments/assets/6833401e-5a61-4738-ac15-01a699b4d35d" width="300" />
<!-- video src="" witdh="300"/>-->
