### PR TITLE
[mod/#78] 자동 미션 등록 로직 및 UI 개선

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,6 @@ val properties = Properties().apply {
     load(project.rootProject.file("local.properties").inputStream())
 }
 
-
 android {
     namespace = "com.kiero"
     compileSdk = libs.versions.compileSdk.get().toInt()
@@ -46,7 +45,6 @@ android {
         // manifestPlaceholders["NATIVE_APP_KEY"] = properties["kakao.native.app.key"].toString().replace("\"", "")
 
     }
-
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -81,6 +79,15 @@ android {
             dimension = "version"
             applicationIdSuffix = ".child"
             resValue("string", "app_name", "Kiero_Kid")
+        }
+    }
+
+    signingConfigs {
+        getByName("debug") {
+            keyAlias = "androiddebugkey"
+            keyPassword = "android"
+            storeFile = File("${project.rootDir.absolutePath}/keystore/debug.keystore")
+            storePassword = "android"
         }
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/ParentAutoAddScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/ParentAutoAddScreen.kt
@@ -51,7 +51,6 @@ fun ParentAutoAddRoute(
     viewModel.sideEffect.collectSideEffect { effect ->
         when (effect) {
             is AutoMissionSideEffect.ShowToast -> {
-                // ParentAutoResultRoute에서 처리
                 snackbarHostState.showSnackbar(effect.message)
             }
 
@@ -61,6 +60,11 @@ fun ParentAutoAddRoute(
 
             is AutoMissionSideEffect.ScrollToPage -> {
                 // 처리 안 함
+            }
+
+            is AutoMissionSideEffect.ShowToastAndNavigate -> {
+                snackbarHostState.showSnackbar(effect.message)
+                navigateUp()
             }
         }
     }
@@ -77,7 +81,8 @@ fun ParentAutoAddRoute(
             ParentAutoResultRoute(
                 paddingValues = paddingValues,
                 state = state,
-                viewModel = viewModel
+                viewModel = viewModel,
+                navigateUp = navigateUp
             )
         }
 

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/ParentAutoAddScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/ParentAutoAddScreen.kt
@@ -37,6 +37,7 @@ import com.kiero.presentation.parent.schedule.mission.auto.component.ScrollableA
 import com.kiero.presentation.parent.schedule.mission.auto.state.AutoMissionSideEffect
 import com.kiero.presentation.parent.schedule.mission.auto.state.AutoMissionState
 import com.kiero.presentation.parent.schedule.mission.auto.viewmodel.AutoMissionViewModel
+import timber.log.Timber
 
 @Composable
 fun ParentAutoAddRoute(
@@ -63,6 +64,7 @@ fun ParentAutoAddRoute(
             }
 
             is AutoMissionSideEffect.ShowToastAndNavigate -> {
+                Timber.e("parent auto add")
                 snackbarHostState.showSnackbar(effect.message)
                 navigateUp()
             }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/ParentAutoResultScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/ParentAutoResultScreen.kt
@@ -36,6 +36,7 @@ import com.kiero.presentation.parent.schedule.mission.auto.state.AutoMissionStat
 import com.kiero.presentation.parent.schedule.mission.auto.viewmodel.AutoMissionViewModel
 import com.kiero.presentation.parent.schedule.mission.component.datepicker.component.CalendarBottomSheet
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.time.LocalDate
 
 
@@ -59,16 +60,15 @@ fun ParentAutoResultRoute(
         viewModel.sideEffect.collect { effect ->
             when (effect) {
                 is AutoMissionSideEffect.ShowToast -> {
-                    scope.launch {
-                        snackbarHostState.currentSnackbarData?.dismiss()
-                        snackbarHostState.showSnackbar(effect.message)
-                    }
+                    snackbarHostState.currentSnackbarData?.dismiss()
+                    snackbarHostState.showSnackbar(effect.message)
                 }
                 is AutoMissionSideEffect.ShowToastAndNavigate -> {
-                    scope.launch {
-                        snackbarHostState.currentSnackbarData?.dismiss()
-                        snackbarHostState.showSnackbar(effect.message)
-                    }
+                    Timber.e("parent Auto result")
+
+                    snackbarHostState.currentSnackbarData?.dismiss()
+                    snackbarHostState.showSnackbar(effect.message)
+
                     navigateUp()
                 }
                 else -> {}

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/ParentAutoResultScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/ParentAutoResultScreen.kt
@@ -43,6 +43,7 @@ import java.time.LocalDate
 fun ParentAutoResultRoute(
     paddingValues: PaddingValues,
     state: AutoMissionState,
+    navigateUp: () -> Unit,
     viewModel: AutoMissionViewModel = hiltViewModel(),
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
@@ -62,6 +63,13 @@ fun ParentAutoResultRoute(
                         snackbarHostState.currentSnackbarData?.dismiss()
                         snackbarHostState.showSnackbar(effect.message)
                     }
+                }
+                is AutoMissionSideEffect.ShowToastAndNavigate -> {
+                    scope.launch {
+                        snackbarHostState.currentSnackbarData?.dismiss()
+                        snackbarHostState.showSnackbar(effect.message)
+                    }
+                    navigateUp()
                 }
                 else -> {}
             }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/state/AutoMissionSideEffect.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/state/AutoMissionSideEffect.kt
@@ -2,6 +2,7 @@ package com.kiero.presentation.parent.schedule.mission.auto.state
 
 sealed interface AutoMissionSideEffect {
     data class ShowToast(val message: String) : AutoMissionSideEffect
+    data class ShowToastAndNavigate(val message: String) : AutoMissionSideEffect
     data object NavigateBack : AutoMissionSideEffect
     data class ScrollToPage(val index: Int) : AutoMissionSideEffect
 }

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/viewmodel/AutoMissionViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/viewmodel/AutoMissionViewModel.kt
@@ -232,6 +232,11 @@ class AutoMissionViewModel @Inject constructor(
             autoMissionRepository.saveBatchMissions(childId, domainMissions)
                 .onSuccess {
                     Timber.e("message saveBatchMissions")
+                    _state.update {
+                        it.copy(
+                            hasViewedLastPage = false
+                        )
+                    }
                     _sideEffect.emit(
                         AutoMissionSideEffect.ShowToastAndNavigate("미션이 등록되었습니다."),
                     )

--- a/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/viewmodel/AutoMissionViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/schedule/mission/auto/viewmodel/AutoMissionViewModel.kt
@@ -35,10 +35,7 @@ class AutoMissionViewModel @Inject constructor(
     private val _state = MutableStateFlow(AutoMissionState())
     val state: StateFlow<AutoMissionState> = _state.asStateFlow()
 
-    private val _sideEffect = MutableSharedFlow<AutoMissionSideEffect>(
-        extraBufferCapacity = 1
-    )
-
+    private val _sideEffect = MutableSharedFlow<AutoMissionSideEffect>()
     val sideEffect: SharedFlow<AutoMissionSideEffect> = _sideEffect.asSharedFlow()
 
     val awardTextFieldState = TextFieldState(initialText = "20")
@@ -234,11 +231,10 @@ class AutoMissionViewModel @Inject constructor(
 
             autoMissionRepository.saveBatchMissions(childId, domainMissions)
                 .onSuccess {
+                    Timber.e("message saveBatchMissions")
                     _sideEffect.emit(
-                        AutoMissionSideEffect.ShowToast("미션이 등록되었습니다.")
+                        AutoMissionSideEffect.ShowToastAndNavigate("미션이 등록되었습니다."),
                     )
-                    delay(200)
-                    _sideEffect.emit(AutoMissionSideEffect.NavigateBack)
                 }
                 .onFailure { e ->
                     val message = when {


### PR DESCRIPTION
## ISSUE
- closed #78 

## ❗ WORK DESCRIPTION
- **자동 미션 등록 후 화면 이동 로직 수정**
    - 미션 등록 성공 시, 토스트 메시지를 표시하고 즉시 이전 화면으로 이동하도록 `ShowToastAndNavigate` `SideEffect`를 추가하고 관련 로직을 수정했습니다.
    - 기존의 `delay`를 사용한 순차적 화면 이동 방식을 제거하여 사용자 경험을 개선했습니다.

- **`SharedFlow` 설정 변경**
    - `AutoMissionViewModel`의 `_sideEffect` `SharedFlow`에서 불필요한 `extraBufferCapacity = 1` 설정을 제거했습니다.

- **디버그 키스토어 설정 추가**
    - `app/build.gradle.kts` 파일에 디버그 빌드를 위한 키스토어(`debug.keystore`) 경로 및 서명 정보를 명시적으로 추가했습니다.

## 📢 TO REVIEWERS
- 고생하셨습니다!!!

## 📸 SCREENSHOT
<img src="" width="300" />
<!-- video src="" witdh="300"/>-->
