### PR TITLE
[fix/#119] 자체 qa 수정사항 반영

### DIFF
--- a/app/src/main/java/com/kiero/core/designsystem/component/KieroSnackbar.kt
+++ b/app/src/main/java/com/kiero/core/designsystem/component/KieroSnackbar.kt
@@ -5,8 +5,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -15,7 +15,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.kiero.core.designsystem.theme.KieroTheme
 
@@ -26,6 +25,7 @@ fun KieroSnackbar(
 ) {
     Box(
         modifier = modifier
+            .wrapContentWidth()
             .clip(RoundedCornerShape(999.dp))
             .background(KieroTheme.colors.gray800)
             .padding(horizontal = 16.dp, vertical = 10.dp),

--- a/app/src/main/java/com/kiero/presentation/kid/mission/KidMissionScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/mission/KidMissionScreen.kt
@@ -47,7 +47,7 @@ import com.kiero.core.designsystem.component.chip.action.KieroCoinAction
 import com.kiero.core.designsystem.component.dialog.KieroDialog
 import com.kiero.core.designsystem.component.dialog.action.KieroCancelAction
 import com.kiero.core.designsystem.component.dialog.action.KieroConfirmAction
-import com.kiero.core.designsystem.component.emptyview.KieroEmptyView
+import com.kiero.core.designsystem.component.emptyview.KieroContentEmptyScreen
 import com.kiero.core.designsystem.component.indicator.KieroLoadingIndicator
 import com.kiero.core.designsystem.component.pulltorefresh.KieroPullToRefresh
 import com.kiero.core.designsystem.theme.KieroTheme
@@ -215,10 +215,10 @@ private fun KidMissionScreen(
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .fillParentMaxHeight(0.8f),
+                            .fillParentMaxHeight(0.6f),
                         contentAlignment = Alignment.Center
                     ) {
-                        KieroEmptyView(
+                        KieroContentEmptyScreen(
                             title = "아직 등록된 미션이 없어!",
                             description = "부모님과 함께 나만의 미션을 정해볼까?",
                         )

--- a/app/src/main/java/com/kiero/presentation/kid/mission/viewmodel/KidMissionViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/mission/viewmodel/KidMissionViewModel.kt
@@ -91,9 +91,10 @@ class KidMissionViewModel @Inject constructor(
                 .onSuccess { result ->
                     Timber.e("fetchMissions $result")
                     minLoadingTime.join()
-                    _state.update {
+                    _state.update { currentState ->
+                        val currentData = currentState.successData ?: KidMissionState()
                         UiState.Success(
-                            KidMissionState(
+                            currentData.copy(
                                 kidMissionByDateList = result.toUiModel(),
                                 isRefreshing = false
                             )
@@ -136,7 +137,6 @@ class KidMissionViewModel @Inject constructor(
                         )
                     }
                     fetchCoin()
-                    fetchMissions()
                 }
                 .onFailure { exception ->
                     _sideEffect.emit(KidMissionSideEffect.ShowSnackbar(exception.message.toString()))

--- a/app/src/main/java/com/kiero/presentation/kid/wish/KidWishScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/wish/KidWishScreen.kt
@@ -42,7 +42,7 @@ import com.kiero.core.designsystem.component.chip.action.KieroCoinAction
 import com.kiero.core.designsystem.component.dialog.KieroDialog
 import com.kiero.core.designsystem.component.dialog.action.KieroCancelAction
 import com.kiero.core.designsystem.component.dialog.action.KieroConfirmAction
-import com.kiero.core.designsystem.component.emptyview.KieroEmptyView
+import com.kiero.core.designsystem.component.emptyview.KieroContentEmptyScreen
 import com.kiero.core.designsystem.component.indicator.KieroLoadingIndicator
 import com.kiero.core.designsystem.component.pulltorefresh.KieroPullToRefresh
 import com.kiero.core.designsystem.theme.KieroTheme
@@ -249,10 +249,12 @@ private fun KidWishScreen(
         Spacer(modifier = Modifier.height(17.dp))
 
         if (state.kidWishList.isEmpty()) {
-            KieroEmptyView(
+            KieroContentEmptyScreen(
                 title = "아직 등록된 보상이 없어!",
                 description = "부모님과 함께 나만의 보상을 정해볼까?",
-                modifier = Modifier.weight(1f)
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(bottom = 80.dp)
             )
         } else {
             KidWishGridList(

--- a/app/src/main/java/com/kiero/presentation/kid/wish/viewmodel/KidWishViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/wish/viewmodel/KidWishViewModel.kt
@@ -101,10 +101,10 @@ class KidWishViewModel @Inject constructor(
             wishRepository.getCoupons()
                 .onSuccess { result ->
                     minLoadingTime.join()
-
-                    _state.update {
+                    _state.update { currentState ->
+                        val currentData = currentState.successData ?: KidWishState()
                         UiState.Success(
-                            data = KidWishState(
+                            currentData.copy(
                                 kidWishList = result.map { wish ->
                                     wish.toUiModel()
                                 }.toImmutableList(),


### PR DESCRIPTION
## ISSUE
- closed #119

## ❗ WORK DESCRIPTION
- 자체적으로 테스트 다시 해보다가 발견한 이슈들 다시 적용했습니다..
- 금화미션, 소원의 우물 - 새로운 State 객체로 덮어씌워지면서 초기화되어서 두번째로 나타나야 할 다이얼로그가 나타나자마자 바로 닫히는 문제가 있었어서 수정했습니다.
- 스낵바가 가로 전체를 차지하고 있어 내용물 크기만큼만 차지하도록 수정했습니다.
- 금화미션, 소원의 우물 - 엠티뷰 높이 수정했습니다.

