### PR TITLE
[mod/#123] 자녀 - 1차 스프린트 QA 2차 반영

### DIFF
--- a/app/src/main/java/com/kiero/core/designsystem/component/KieroTopbar.kt
+++ b/app/src/main/java/com/kiero/core/designsystem/component/KieroTopbar.kt
@@ -29,7 +29,7 @@ fun KieroTopbar(
     title: String,
     leftIconClick: () -> Unit,
     modifier: Modifier = Modifier,
-    @DrawableRes leftIconRes: Int = R.drawable.ic_arrow_left,
+    @DrawableRes leftIconRes: Int? = R.drawable.ic_arrow_left,
     rightIconRes: Int? = null,
     rightIconClick: () -> Unit = {},
     textStyle: TextStyle = KieroTheme.typography.bold.headLine2,
@@ -46,13 +46,15 @@ fun KieroTopbar(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        Icon(
-            imageVector = ImageVector.vectorResource(id = leftIconRes),
-            contentDescription = null,
-            tint = KieroTheme.colors.white,
-            modifier = Modifier
-                .noRippleClickable(onClick = leftIconClick)
-        )
+        leftIconRes?.let {
+            Icon(
+                imageVector = ImageVector.vectorResource(id = it),
+                contentDescription = null,
+                tint = KieroTheme.colors.white,
+                modifier = Modifier
+                    .noRippleClickable(onClick = leftIconClick)
+            )
+        }
 
         Text(
             text = title,

--- a/app/src/main/java/com/kiero/core/designsystem/component/chip/action/KieroStoneAction.kt
+++ b/app/src/main/java/com/kiero/core/designsystem/component/chip/action/KieroStoneAction.kt
@@ -32,7 +32,6 @@ class KieroStoneAction(
         val targetColor = when {
             !isEnabled -> KieroTheme.colors.gray500
             isFireLit -> KieroTheme.colors.main
-            isCompleted && maxStoneCount > 0 -> KieroTheme.colors.main
             else -> KieroTheme.colors.gray100
         }
 

--- a/app/src/main/java/com/kiero/core/designsystem/component/chip/action/KieroStoneAction.kt
+++ b/app/src/main/java/com/kiero/core/designsystem/component/chip/action/KieroStoneAction.kt
@@ -31,7 +31,8 @@ class KieroStoneAction(
 
         val targetColor = when {
             !isEnabled -> KieroTheme.colors.gray500
-            isCompleted && maxStoneCount > 0 && !isFireLit -> KieroTheme.colors.main
+            isFireLit -> KieroTheme.colors.main
+            isCompleted && maxStoneCount > 0 -> KieroTheme.colors.main
             else -> KieroTheme.colors.gray100
         }
 

--- a/app/src/main/java/com/kiero/presentation/kid/journey/KidJourneyScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/KidJourneyScreen.kt
@@ -4,6 +4,12 @@ import android.Manifest
 import android.content.pm.PackageManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -99,6 +105,7 @@ fun KidJourneyRoute(
             is KidJourneySideEffect.ShowSnackbar -> globalTrigger.showSnackbar(
                 SnackbarState(message = sideEffect.message)
             )
+
             KidJourneySideEffect.ShowDialog -> globalTrigger.dialogTrigger.show {}
         }
     }
@@ -213,12 +220,22 @@ private fun KidJourneyScreen(
                 )
             }
 
-            if (state.shouldShowSchedule) {
-                Spacer(modifier = Modifier.height(21.dp))
+            AnimatedVisibility(
+                visible = state.shouldShowSchedule && state.currentScheduleInfo != null,
+                enter = expandVertically(
+                    animationSpec = tween(durationMillis = 300)
+                ) + fadeIn(),
+                exit = shrinkVertically() + fadeOut(),
+                label = "ScheduleItemAnimation"
+            ) {
+                Column {
+                    Spacer(modifier = Modifier.height(21.dp))
 
-                state.currentScheduleInfo?.let { schedule ->
-                    KidJourneyScheduleItem(item = schedule)
+                    state.currentScheduleInfo?.let { schedule ->
+                        KidJourneyScheduleItem(item = schedule)
+                    }
                 }
+
             }
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/kiero/presentation/kid/journey/KidJourneyScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/KidJourneyScreen.kt
@@ -216,7 +216,7 @@ private fun KidJourneyScreen(
             state.header?.let { header ->
                 KidJourneyHeader(
                     header = header,
-                    isFireLit = state.content == KidJourneyContentUiModel.FireLit
+                    isFireLit = state.buttonType == KidJourneyButtonType.FIRE
                 )
             }
 

--- a/app/src/main/java/com/kiero/presentation/kid/journey/camera/KidCameraScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/camera/KidCameraScreen.kt
@@ -65,6 +65,8 @@ fun KidCameraRoute(
                 fileName = "${System.currentTimeMillis()}.jpg",
                 contentType = "image/jpeg"
             )
+        } else {
+            navigateUp()
         }
     }
 

--- a/app/src/main/java/com/kiero/presentation/kid/journey/component/KidJourneyHeader.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/component/KidJourneyHeader.kt
@@ -68,8 +68,7 @@ fun KidJourneyHeader(
                     onClick = {}
                 ),
                 isEnabled = true,
-                isCompleted = isFireLit || header.earnedStones == header.totalScheduleCount
-                        && header.totalScheduleCount > 0
+                isCompleted = isFireLit
             )
         }
     }

--- a/app/src/main/java/com/kiero/presentation/kid/journey/component/KidJourneyHeader.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/component/KidJourneyHeader.kt
@@ -68,7 +68,7 @@ fun KidJourneyHeader(
                     onClick = {}
                 ),
                 isEnabled = true,
-                isCompleted = !isFireLit && header.earnedStones == header.totalScheduleCount
+                isCompleted = isFireLit || header.earnedStones == header.totalScheduleCount
                         && header.totalScheduleCount > 0
             )
         }

--- a/app/src/main/java/com/kiero/presentation/kid/journey/fire/KidFIreResultScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/fire/KidFIreResultScreen.kt
@@ -1,5 +1,6 @@
 package com.kiero.presentation.kid.journey.fire
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -56,6 +57,8 @@ fun KidFireResultRoute(
     viewModel: KidFireResultVIewModel = hiltViewModel()
 ) {
     val state by viewModel.fireResultState.collectAsStateWithLifecycle()
+
+    BackHandler{}
 
     when (val state = state) {
         is UiState.Success -> {

--- a/app/src/main/java/com/kiero/presentation/kid/journey/fire/KidFIreResultScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/fire/KidFIreResultScreen.kt
@@ -115,8 +115,8 @@ private fun KidFIreResultScreen(
         ) {
             KieroTopbar(
                 title = state.date,
-                leftIconRes = R.drawable.ic_arrow_left,
-                leftIconClick = navigateUp,
+                leftIconRes = null,
+                leftIconClick = {},
                 modifier = Modifier
                     .padding(top = 20.dp)
                     .alpha(if (!isFinished) 1f else 0f),

--- a/app/src/main/java/com/kiero/presentation/kid/journey/map/KidMapScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/map/KidMapScreen.kt
@@ -7,12 +7,15 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -97,10 +100,29 @@ private fun KidMapScreen(
 
                     Spacer(modifier = Modifier.height(25.dp))
 
-                    KidMapScheduleList(
-                        schedules = state.schedules,
+                    Box(
                         modifier = Modifier.weight(1f)
-                    )
+                    ) {
+                        KidMapScheduleList(
+                            schedules = state.schedules,
+                            modifier = Modifier.fillMaxSize()
+                        )
+
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .fillMaxWidth()
+                                .height(54.dp)
+                                .background(
+                                    brush = Brush.verticalGradient(
+                                        colors = listOf(
+                                            Color(0x00232428),
+                                            Color(0xFF232428)
+                                        )
+                                    )
+                                )
+                        )
+                    }
                 } else {
                     KidMapEmptyView(
                         modifier = Modifier.weight(1f)

--- a/app/src/main/java/com/kiero/presentation/kid/journey/map/component/KidMapListItem.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/map/component/KidMapListItem.kt
@@ -26,18 +26,21 @@ fun KidMapListItem(
     modifier: Modifier = Modifier
 ) {
     val nameColor = when {
-        item.isOngoing || item.status == KidMapScheduleStatus.PENDING -> KieroTheme.colors.white
+        item.isOngoing || item.status == KidMapScheduleStatus.PENDING
+                || item.status == KidMapScheduleStatus.VERIFIED -> KieroTheme.colors.white
         else -> KieroTheme.colors.white.copy(alpha = 0.5f)
     }
 
     val timeColor = when {
-        item.isOngoing || item.isNext -> KieroTheme.colors.main
+        item.isOngoing || item.isNext
+                || item.status == KidMapScheduleStatus.VERIFIED -> KieroTheme.colors.main
         item.status == KidMapScheduleStatus.PENDING -> KieroTheme.colors.gray500
         else -> KieroTheme.colors.gray500.copy(alpha = 0.5f)
     }
 
     val dividerColor = when {
-        item.isOngoing || item.isNext || item.status == KidMapScheduleStatus.PENDING -> KieroTheme.colors.gray600
+        item.isOngoing || item.isNext || item.status == KidMapScheduleStatus.PENDING
+                || item.status == KidMapScheduleStatus.VERIFIED -> KieroTheme.colors.gray600
         else -> Color.Transparent
     }
 

--- a/app/src/main/java/com/kiero/presentation/kid/journey/map/component/KidMapTimelineNode.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/map/component/KidMapTimelineNode.kt
@@ -27,9 +27,10 @@ fun KidMapTimelineNode(
     isNext: Boolean = false
 ) {
     val showLine = isOngoing || isNext || status == KidMapScheduleStatus.PENDING
+            || status == KidMapScheduleStatus.VERIFIED
 
     val iconColor = when {
-        isOngoing || isNext -> KieroTheme.colors.main
+        isOngoing || isNext || status == KidMapScheduleStatus.VERIFIED -> KieroTheme.colors.main
         status == KidMapScheduleStatus.PENDING -> KieroTheme.colors.white
         else -> KieroTheme.colors.white.copy(alpha = 0.5f)
     }

--- a/app/src/main/java/com/kiero/presentation/kid/journey/map/model/KidMapItemUiModel.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/map/model/KidMapItemUiModel.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Immutable
 import com.kiero.core.common.extension.toKoreanTimeString
 import com.kiero.data.kid.schedule.model.ScheduleProgressItemModel
 import com.kiero.presentation.kid.journey.model.KidJourneyStoneType
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @Immutable
 data class KidMapItemUiModel(
@@ -38,7 +40,7 @@ fun ScheduleProgressItemModel.toUiModel(isFireLitToday: Boolean): KidMapItemUiMo
     )
 }
 
-fun List<ScheduleProgressItemModel>.toUiModelList(isFireLitToday: Boolean): List<KidMapItemUiModel> {
+fun List<ScheduleProgressItemModel>.toUiModelList(isFireLitToday: Boolean): ImmutableList<KidMapItemUiModel> {
     val mappedList = this.map { it.toUiModel(isFireLitToday) }.toMutableList()
 
     if (!isFireLitToday) {
@@ -53,5 +55,5 @@ fun List<ScheduleProgressItemModel>.toUiModelList(isFireLitToday: Boolean): List
         }
     }
 
-    return mappedList
+    return mappedList.toImmutableList()
 }

--- a/app/src/main/java/com/kiero/presentation/kid/journey/map/model/KidMapItemUiModel.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/map/model/KidMapItemUiModel.kt
@@ -22,26 +22,34 @@ fun ScheduleProgressItemModel.toUiModel(isFireLitToday: Boolean): KidMapItemUiMo
     val validIsOngoing = this.isOngoing && !isFireLitToday &&
             (mappedStatus == KidMapScheduleStatus.PENDING || mappedStatus == KidMapScheduleStatus.VERIFIED)
 
+    val finalStatus = if (isFireLitToday && mappedStatus == KidMapScheduleStatus.VERIFIED) {
+        KidMapScheduleStatus.COMPLETED
+    } else {
+        mappedStatus
+    }
+
     return KidMapItemUiModel(
         name = this.name,
         startTime = this.startTime.toKoreanTimeString(),
         endTime = this.endTime.toKoreanTimeString(),
         isOngoing = validIsOngoing,
         stoneType = KidJourneyStoneType.from(this.stoneType),
-        status = mappedStatus
+        status = finalStatus
     )
 }
 
 fun List<ScheduleProgressItemModel>.toUiModelList(isFireLitToday: Boolean): List<KidMapItemUiModel> {
     val mappedList = this.map { it.toUiModel(isFireLitToday) }.toMutableList()
 
-    val hasOngoing = mappedList.any { it.isOngoing }
-    val hasVerified = mappedList.any { it.status == KidMapScheduleStatus.VERIFIED }
+    if (!isFireLitToday) {
+        val hasOngoing = mappedList.any { it.isOngoing }
+        val hasVerified = mappedList.any { it.status == KidMapScheduleStatus.VERIFIED }
 
-    if (!hasOngoing && !hasVerified) {
-        val pendingIndex = mappedList.indexOfFirst { it.status == KidMapScheduleStatus.PENDING }
-        if (pendingIndex != -1) {
-            mappedList[pendingIndex] = mappedList[pendingIndex].copy(isNext = true)
+        if (!hasOngoing && !hasVerified) {
+            val pendingIndex = mappedList.indexOfFirst { it.status == KidMapScheduleStatus.PENDING }
+            if (pendingIndex != -1) {
+                mappedList[pendingIndex] = mappedList[pendingIndex].copy(isNext = true)
+            }
         }
     }
 

--- a/app/src/main/java/com/kiero/presentation/kid/journey/map/model/KidMapItemUiModel.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/map/model/KidMapItemUiModel.kt
@@ -36,8 +36,9 @@ fun List<ScheduleProgressItemModel>.toUiModelList(isFireLitToday: Boolean): List
     val mappedList = this.map { it.toUiModel(isFireLitToday) }.toMutableList()
 
     val hasOngoing = mappedList.any { it.isOngoing }
+    val hasVerified = mappedList.any { it.status == KidMapScheduleStatus.VERIFIED }
 
-    if (!hasOngoing) {
+    if (!hasOngoing && !hasVerified) {
         val pendingIndex = mappedList.indexOfFirst { it.status == KidMapScheduleStatus.PENDING }
         if (pendingIndex != -1) {
             mappedList[pendingIndex] = mappedList[pendingIndex].copy(isNext = true)

--- a/app/src/main/java/com/kiero/presentation/kid/mission/KidMissionScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/mission/KidMissionScreen.kt
@@ -215,7 +215,7 @@ private fun KidMissionScreen(
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .fillParentMaxHeight(0.6f),
+                            .fillParentMaxHeight(0.7f),
                         contentAlignment = Alignment.Center
                     ) {
                         KieroContentEmptyScreen(

--- a/app/src/main/java/com/kiero/presentation/kid/onboarding/component/KidOnboardingMessage.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/onboarding/component/KidOnboardingMessage.kt
@@ -38,7 +38,7 @@ fun KidOnboardingMessage(
                 style = textStyle
             )
             Text(
-                text = "난 '영웅의 불씨'를 품고 태어난 특별한 도꺠비야!",
+                text = "난 '영웅의 불씨'를 품고 태어난 특별한 도깨비야!",
                 color = defaultColor,
                 style = textStyle
             )

--- a/app/src/main/java/com/kiero/presentation/kid/wish/KidWishScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/wish/KidWishScreen.kt
@@ -254,7 +254,6 @@ private fun KidWishScreen(
                 description = "부모님과 함께 나만의 보상을 정해볼까?",
                 modifier = Modifier
                     .weight(1f)
-                    .padding(bottom = 80.dp)
             )
         } else {
             KidWishGridList(

--- a/app/src/main/java/com/kiero/presentation/main/screen/MainScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/main/screen/MainScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -209,7 +208,6 @@ fun MainScreen(
                     else -> KieroTheme.colors.black
                 })
                 .navigationBarsPadding()
-                .statusBarsPadding()
         ) {
             Scaffold(
                 containerColor = KieroTheme.colors.black,


### PR DESCRIPTION
## ISSUE
- closed #123

## ❗ WORK DESCRIPTION

공통
- 상태바 투명하게 수정 -> MainScreen의 statusBarsPadding() 속성 제거

아이 온보딩
- 도꺠비 -> 도깨비 오타 수정

여정뷰 
- 여정 없다가 생겼을 때 시간 바 인터렉션 추가
- 마음의 불피우기 버튼이 활성화될 때 kierochip 색상 항상 main색으로 변경
- 불피우기 끝나면 오늘 하루의 모든 일정이 끝난 것이므로 하이라이팅 모두 제거

카메라
- 카메라화면에서 시스템 뒤로가기 시 박스의 (조건문에 따라) 빈화면이 나타나던 문제 해결 - navigateUp 추가

불피우기
- 불피우기 결과 화면에 뒤로가기 버튼 제거, 시스템 뒤로가기도 막음. 

맵뷰
- 스크롤할 때 버튼아래 리스트에 그라데이션 추가
- 여정 인증하고 다음여정으로 이동하기 전, 현재 일정이 진행중인 상황에서는 아직 일정이 끝난게 아니므로 라인과 텍스트 색이 활성화 상태여야 함 -> verified 속성에 대한 조건 추가

금화 미션, 소원의 우물
- 엠티뷰 높이 통일

