### PR TITLE
[fix/#127] 보상 아이, 부모 화면 - 텍스트 한 줄 제한 및 말줄임표 적용

### DIFF
--- a/app/src/main/java/com/kiero/presentation/kid/wish/component/KidWishGridItem.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/wish/component/KidWishGridItem.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kiero.core.common.extension.noRippleClickable
@@ -43,7 +44,9 @@ fun KidWishGridItem(
         Text(
             text = missionTitle,
             style = KieroTheme.typography.regular.body3,
-            color = KieroTheme.colors.white
+            color = KieroTheme.colors.white,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
         )
 
         Spacer(modifier = Modifier.height(14.dp))

--- a/app/src/main/java/com/kiero/presentation/parent/screen/reward/component/ParentRewardCard.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/reward/component/ParentRewardCard.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kiero.core.designsystem.component.chip.KieroChip
@@ -42,6 +43,8 @@ fun ParentRewardCard(
                 text = name,
                 style = KieroTheme.typography.regular.body3,
                 color = KieroTheme.colors.white,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
 
             KieroChip(

--- a/app/src/main/java/com/kiero/presentation/parent/screen/reward/component/RewardNameTextField.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/reward/component/RewardNameTextField.kt
@@ -36,7 +36,7 @@ fun RewardNameTextField(
 
     BasicTextField(
         state = state,
-        inputTransformation = InputTransformation.maxLength(15),
+        inputTransformation = InputTransformation.maxLength(13),
         lineLimits = TextFieldLineLimits.SingleLine,
         keyboardOptions = KeyboardOptions(
             imeAction = ImeAction.Done,


### PR DESCRIPTION
## ISSUE
- closed #127

## ❗ WORK DESCRIPTION
- 보상 부모, 아이 화면 - 텍스트를 한 줄로 제한하고 텍스트가 너무 길 때 말줄임표를 적용하였습니다.


## 📸 SCREENSHOT
<img width="300" alt="image" src="https://github.com/user-attachments/assets/98c91640-53ec-46e3-89b4-0cb7389cd960" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/548a45b6-8797-461e-94e0-851478272dc3" />
