### PR TITLE
[mod#135] first sprint qa 3

### DIFF
--- a/app/src/main/java/com/kiero/presentation/auth/AuthScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/auth/AuthScreen.kt
@@ -71,7 +71,6 @@ fun AuthScreen(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .navigationBarsPadding()
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             Image(

--- a/app/src/main/java/com/kiero/presentation/auth/AuthScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/auth/AuthScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -70,6 +71,7 @@ fun AuthScreen(
     Box(
         modifier = modifier
             .fillMaxSize()
+            .navigationBarsPadding()
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             Image(

--- a/app/src/main/java/com/kiero/presentation/main/activity/MainActivity.kt
+++ b/app/src/main/java/com/kiero/presentation/main/activity/MainActivity.kt
@@ -26,13 +26,11 @@ class MainActivity : ComponentActivity() {
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
 
         enableEdgeToEdge(
-            statusBarStyle = SystemBarStyle.auto(
-                Color.TRANSPARENT,
-                Color.TRANSPARENT
+            statusBarStyle = SystemBarStyle.dark(
+                scrim = Color.TRANSPARENT
             ),
-            navigationBarStyle = SystemBarStyle.auto(
-                Color.TRANSPARENT,
-                Color.TRANSPARENT
+            navigationBarStyle = SystemBarStyle.dark(
+                scrim = Color.TRANSPARENT
             )
         )
 

--- a/app/src/main/java/com/kiero/presentation/main/component/ParentTopbar.kt
+++ b/app/src/main/java/com/kiero/presentation/main/component/ParentTopbar.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -42,9 +43,9 @@ fun ParentTopbar(
             .background(
                 color = backgroundColor
             )
-            .padding(top = 24.dp, bottom = 9.dp)
+            .statusBarsPadding()
             .padding(top = 16.dp)
-            .padding(horizontal = 16.dp)
+            .padding(horizontal = 16.dp, vertical = 9.dp)
             .height(IntrinsicSize.Min),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app/src/main/java/com/kiero/presentation/main/component/ParentTopbar.kt
+++ b/app/src/main/java/com/kiero/presentation/main/component/ParentTopbar.kt
@@ -46,7 +46,7 @@ fun ParentTopbar(
             .statusBarsPadding()
             .padding(top = 16.dp)
             .padding(horizontal = 16.dp, vertical = 9.dp)
-            .height(IntrinsicSize.Min),
+            .height(41.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (title.isEmpty()) {

--- a/app/src/main/java/com/kiero/presentation/main/screen/MainScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/main/screen/MainScreen.kt
@@ -5,10 +5,14 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.windowInsetsTopHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -205,11 +209,18 @@ fun MainScreen(
         Box(
             modifier = modifier
                 .fillMaxSize()
-                .background(when (currentTab) {
-                    ParentMainTab.JOURNEY -> KieroTheme.colors.gray900
-                    else -> KieroTheme.colors.black
-                })
+                .background(KieroTheme.colors.black)
+                .navigationBarsPadding()
         ) {
+            if (currentTab == ParentMainTab.JOURNEY) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .windowInsetsTopHeight(WindowInsets.statusBars)
+                        .background(KieroTheme.colors.gray900)
+                )
+            }
+
             Scaffold(
                 containerColor = KieroTheme.colors.black,
                 snackbarHost = {

--- a/app/src/main/java/com/kiero/presentation/main/screen/MainScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/main/screen/MainScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost

--- a/app/src/main/java/com/kiero/presentation/parent/screen/journey/ParentJourneyContract.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/journey/ParentJourneyContract.kt
@@ -1,5 +1,6 @@
 package com.kiero.presentation.parent.screen.journey
 
+import androidx.constraintlayout.compose.DesignElements.map
 import com.kiero.data.parent.journey.model.ParentJourneyScheduleModel
 import com.kiero.presentation.parent.screen.journey.extension.toLocalTime
 import com.kiero.presentation.parent.screen.journey.model.JourneyMissionUiModel
@@ -60,15 +61,15 @@ data class ParentJourneyState(
 
 // 현재일정 , 다음일정 텍스트O
 fun List<ParentJourneyScheduleModel>.toUiModels(currentTime: LocalTime): List<TodayJourneyUiModel> {
-
-    val hasOngoingSchedule = any { schedule ->
-        val start = schedule.startTime.toLocalTime()
-        val end = schedule.endTime.toLocalTime()
-        start != null && end != null && currentTime >= start && currentTime < end
+    // isOngoing=true이면서 PENDING/VERIFIED/COMPLETED인 경우만 현재 진행 중으로 인정
+    // SKIPPED/FAILED는 isOngoing=true여도 종료된 것으로 처리
+    val activeOngoing = find {
+        it.isOngoing && it.status != "SKIPPED" && it.status != "FAILED"
     }
+    val hasOngoingSchedule = activeOngoing != null
 
-    // 항상 다음 일정 id 찾기
-    val nextUpcomingId = filter { schedule ->
+    val nextUpcomingId = if (hasOngoingSchedule) null
+    else filter { schedule ->
         val start = schedule.startTime.toLocalTime()
         schedule.status == "PENDING" && start != null && start.isAfter(currentTime)
     }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/journey/ParentJourneyScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/journey/ParentJourneyScreen.kt
@@ -98,6 +98,7 @@ private fun ParentJourneyScreen(
 
     BoxWithConstraints(
         modifier = Modifier.fillMaxSize()
+            .background(KieroTheme.colors.black)
     ) {
         val topBarHeight = paddingValues.calculateTopPadding()
         val targetSheetHeight = this.maxHeight - topBarHeight

--- a/app/src/main/java/com/kiero/presentation/parent/screen/journey/component/ParentJourneyTodayKidInfo.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/journey/component/ParentJourneyTodayKidInfo.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -15,6 +16,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
@@ -33,6 +35,7 @@ fun ParentJourneyTodayKidInfo(
     Row (
         modifier = modifier
             .fillMaxWidth()
+            .defaultMinSize(minHeight = 96.dp)
             .height(IntrinsicSize.Min),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -69,7 +72,7 @@ fun ParentJourneyTodayKidInfo(
             modifier = Modifier
                 .fillMaxHeight()
                 .padding(end = 10.dp)
-                .aspectRatio(84f/100f)
+                .aspectRatio(84f/96f)
         )
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/journey/component/ParentJourneyTodayStatusItem.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/journey/component/ParentJourneyTodayStatusItem.kt
@@ -102,7 +102,8 @@ private fun ParentJourneyToday(
     }
 
     val cardBackground = when {
-        item.todayStatus == TodayStatus.CURRENT_COMPLETED && item.isAuthenticated ->
+        item.todayStatus == TodayStatus.CURRENT_COMPLETED ||
+                item.todayStatus == TodayStatus.NEXT_UPCOMING ->
             KieroTheme.colors.schedule1.copy(alpha = 0.1f)
         else -> KieroTheme.colors.black
     }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/journey/extension/StringExt.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/journey/extension/StringExt.kt
@@ -8,29 +8,17 @@ fun String.toTodayStatus(
     startTime: String,
     endTime: String,
     currentTime: LocalTime,
+    isOngoing: Boolean,
     isNextUpcoming: Boolean = false
 ): TodayStatus {
-    val start = runCatching {
-        LocalTime.parse(startTime.take(5), ALARM_TIME_FORMATTER)
-    }.getOrNull()
-
-    val end = runCatching {
-        LocalTime.parse(endTime.take(5), ALARM_TIME_FORMATTER)
-    }.getOrNull()
-
     return when (this) {
         "PENDING" -> when {
-            // 현재 시간이 시작~종료 사이 → 현재 일정
-            start != null && end != null && currentTime >= start && currentTime < end ->
-                TodayStatus.CURRENT_COMPLETED
-            // 현재 시간이 시작 이전이고 바로 다음 일정 → 현재 일정으로 활성화
-            start != null && currentTime < start && isNextUpcoming ->
-                TodayStatus.NEXT_UPCOMING
+            isOngoing -> TodayStatus.CURRENT_COMPLETED
+            isNextUpcoming -> TodayStatus.NEXT_UPCOMING
             else -> TodayStatus.UPCOMING
         }
         "VERIFIED", "COMPLETED" -> when {
-            start != null && end != null && currentTime >= start && currentTime < end ->
-                TodayStatus.CURRENT_COMPLETED
+            isOngoing -> TodayStatus.CURRENT_COMPLETED
             else -> TodayStatus.PAST_COMPLETED
         }
         "FAILED", "SKIPPED" -> TodayStatus.PAST_MISSED

--- a/app/src/main/java/com/kiero/presentation/parent/screen/journey/model/TodayJourneyUiModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/journey/model/TodayJourneyUiModel.kt
@@ -25,6 +25,7 @@ fun ParentJourneyScheduleModel.toUiModel(
         startTime = startTime,
         endTime = endTime,
         currentTime = currentTime,
+        isOngoing = isOngoing,
         isNextUpcoming = isNextUpcoming && !hasOngoingSchedule
     )
 
@@ -35,9 +36,9 @@ fun ParentJourneyScheduleModel.toUiModel(
         isAuthenticated = status == "VERIFIED" || status == "COMPLETED",
         isOngoing = isOngoing,
         todayStatus = todayStatus,
-        scheduleLabel = when {
-            todayStatus == TodayStatus.CURRENT_COMPLETED -> "현재 일정"
-            isNextUpcoming -> "다음 일정" // PAST_COMPLETED + isNextUpcoming → "다음 일정"
+        scheduleLabel = when (todayStatus) {
+            TodayStatus.CURRENT_COMPLETED -> "현재 일정"
+            TodayStatus.NEXT_UPCOMING -> "다음 일정"
             else -> ""
         }
     )


### PR DESCRIPTION
## ISSUE
- closed #135 

## ❗ WORK DESCRIPTION
**QA 시트 사항을 수정하였습니다**
   - 바텀 시트의 영역 높이 수정
   - 오늘 현황 텍스트 표기 및 하이라이팅 조건 분기 수정 🥵
   - 바텀바와 EdgeToEdge 영역 및 색상 수정
   - 탑바 높이 고정 -> 안드로이드 공식 TopBar compose API가 구현 상 높이가 64.dp로 고정 값으로 구현 (구글의 Material Design 3 공식 사이트(m3.material.io)의 [Components > Top app bars > Specs 또는 선언 후 타고 들어가보기) 되어 있어 탑바는 높이가 고정되어 디자인 스펙을 맞추는게 우선이라 생각해서 고정했습니다
   
## 📢 TO REVIEWERS
- 그만..그만,,, 이제는 진짜 안될...수가 없다
