### PR TITLE
[feat/#171] SP2 자녀 오늘의 여정 - 여정 끝내기

### DIFF
--- a/app/src/main/java/com/kiero/presentation/kid/journey/KidJourneyScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/KidJourneyScreen.kt
@@ -53,9 +53,9 @@ import com.kiero.core.designsystem.component.indicator.KieroLoadingIndicator
 import com.kiero.core.designsystem.theme.KieroTheme
 import com.kiero.core.model.UiState
 import com.kiero.core.model.trigger.SnackbarState
+import com.kiero.core.permission.PermissionChecker
 import com.kiero.core.permission.model.PermissionType
 import com.kiero.core.permission.ui.rememberPermissionRequester
-import com.kiero.core.permission.util.navigateToSettings
 import com.kiero.core.trigger.LocalGlobalUiEventTrigger
 import com.kiero.core.trigger.LocalRefreshState
 import com.kiero.presentation.kid.component.KidSpeechField
@@ -113,7 +113,6 @@ fun KidJourneyRoute(
         is UiState.Success -> {
             val onNavigateToCamera = {
                 val content = state.data.content
-
                 if (content is KidJourneyContentUiModel.ScheduledContent) {
                     navigateToCamera(content.scheduleDetailId!!, content.stoneType!!)
                 }
@@ -134,15 +133,27 @@ fun KidJourneyRoute(
                 onCountIncrease = viewModel::increaseDeniedCount,
             )
 
+            // 최초 데이터 로드 완료 시 알림 권한 체크
+            LaunchedEffect(Unit) {
+                val isGranted = PermissionChecker.isGranted(context, PermissionType.POST_NOTIFICATIONS)
+                viewModel.checkNotificationPermission(isAlreadyGranted = isGranted)
+            }
+
+            val requestNotification = rememberPermissionRequester(
+                type = PermissionType.POST_NOTIFICATIONS,
+                deniedCount = state.data.permissionNotificationDeniedCount,
+                onGranted = { viewModel.onNotificationPermissionDialogDismiss() },
+                onDenied = { viewModel.onNotificationPermissionDialogDismiss() },
+                onPermanentlyDenied = { viewModel.onNotificationPermissionDialogDismiss() },
+                onCountIncrease = viewModel::increaseDeniedCount,
+            )
+
             KidJourneyScreen(
                 paddingValues = paddingValues,
                 state = state.data,
                 onButtonClick = {
                     when (state.data.buttonType) {
-                        KidJourneyButtonType.AUTH -> {
-                            requestCamera()
-                        }
-
+                        KidJourneyButtonType.AUTH -> requestCamera()
                         KidJourneyButtonType.FIRE -> {
                             navigateToFire(
                                 state.data.header!!.currentDate,
@@ -154,19 +165,18 @@ fun KidJourneyRoute(
                     }
                 },
                 onNextClick = viewModel::onNextClick,
+                onFinishClick = viewModel::onNextClick,
                 onMapClick = { navigateToMap(state.data.header!!.currentDate) },
                 navigateUp = navigateUp,
+                onNotificationPermissionConfirm = { requestNotification() },
+                onNotificationPermissionDismiss = viewModel::onNotificationPermissionDialogDismiss,
             )
         }
 
         UiState.Empty -> {}
         is UiState.Failure -> {}
-
-        UiState.Loading -> {
-            KieroLoadingIndicator()
-        }
+        UiState.Loading -> KieroLoadingIndicator()
     }
-
 }
 
 @Composable
@@ -175,11 +185,15 @@ private fun KidJourneyScreen(
     state: KidJourneyState,
     onButtonClick: () -> Unit,
     onNextClick: () -> Unit,
+    onFinishClick: () -> Unit,
     onMapClick: () -> Unit,
     navigateUp: () -> Unit,
+    onNotificationPermissionConfirm: () -> Unit,
+    onNotificationPermissionDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var showDialog by remember { mutableStateOf(false) }
+    var showNextDialog by remember { mutableStateOf(false) }
+    var showFinishDialog by remember { mutableStateOf(false) }
 
     BoxWithConstraints(
         modifier = modifier
@@ -189,7 +203,6 @@ private fun KidJourneyScreen(
     ) {
         val imageWidth = maxWidth + 8.dp
 
-        // 배경 이미지
         Image(
             painter = painterResource(id = R.drawable.img_kid_journey_mask_background),
             contentDescription = null,
@@ -232,7 +245,6 @@ private fun KidJourneyScreen(
                         KidJourneyScheduleItem(item = schedule)
                     }
                 }
-
             }
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -272,17 +284,20 @@ private fun KidJourneyScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(top = 9.dp),
-                isVisibleButton = state.shouldShowNextButton,
-                onClick = { showDialog = true }
+                isVisibleButton = state.shouldShowNextButton || state.shouldShowFinishButton,
+                onClick = {
+                    when {
+                        state.shouldShowFinishButton -> showFinishDialog = true
+                        state.shouldShowNextButton -> showNextDialog = true
+                    }
+                },
+                buttonText = if (state.shouldShowFinishButton) "여정 끝내기" else "다음 여정으로"
             ) {
-                KidJourneyGoblinMessage(
-                    content = state.content
-                )
+                KidJourneyGoblinMessage(content = state.content)
             }
 
             Spacer(modifier = Modifier.height(11.dp))
 
-            // 액션 버튼 (특정 상태에서만 표시)
             KidJourneyActionButton(
                 buttonType = state.buttonType,
                 buttonTextRes = state.buttonTextRes,
@@ -290,7 +305,6 @@ private fun KidJourneyScreen(
             )
         }
 
-        // 꾸비 gif
         KieroAnimationView(
             type = KieroAnimationType.Image(R.drawable.webp_kid_intro),
             modifier = Modifier
@@ -299,21 +313,52 @@ private fun KidJourneyScreen(
         )
     }
 
-    if (showDialog) {
+    // 다음 여정 다이얼로그
+    if (showNextDialog) {
         KieroDialog(
-            onDismiss = { showDialog = false },
+            onDismiss = { showNextDialog = false },
             title = "다음 여정으로 갈거야?",
             subDescription = "한 번 다음 여정으로 넘어가면 \n다시 지금 여정으로 돌아올 수 없어!",
-            cancelAction = KieroCancelAction(
-                text = "취소",
-                onClick = { showDialog = false }
-            ),
+            cancelAction = KieroCancelAction(text = "취소", onClick = { showNextDialog = false }),
             confirmAction = KieroConfirmAction(
                 text = "확인",
                 onClick = {
-                    showDialog = false
+                    showNextDialog = false
                     onNextClick()
                 }
+            ),
+            content = {}
+        )
+    }
+
+    // 여정 끝내기 다이얼로그
+    if (showFinishDialog) {
+        KieroDialog(
+            onDismiss = { showFinishDialog = false },
+            title = "오늘의 여정을 끝낼거야?",
+            subDescription = "한 번 오늘 여정을 끝내면 \n다시 오늘의 여정으로 돌아올 수 없어!",
+            cancelAction = KieroCancelAction(text = "취소", onClick = { showFinishDialog = false }),
+            confirmAction = KieroConfirmAction(
+                text = "끝내기",
+                onClick = {
+                    showFinishDialog = false
+                    onFinishClick()
+                }
+            ),
+            content = {}
+        )
+    }
+
+    // 최초 알림 권한 요청 팝업
+    if (state.showNotificationPermissionDialog) {
+        KieroDialog(
+            onDismiss = onNotificationPermissionDismiss,
+            title = "오늘의 여정을 놓치지 않게 해줄게!",
+            subDescription = "여정의 중요한 알림을 받아볼 수 있어.",
+            cancelAction = null,
+            confirmAction = KieroConfirmAction(
+                text = "알림 받기",
+                onClick = onNotificationPermissionConfirm
             ),
             content = {}
         )
@@ -330,7 +375,10 @@ private fun KidJourneyScreenPreview() {
             state = KidJourneyState.FAKE,
             onButtonClick = {},
             onNextClick = {},
-            onMapClick = {}
+            onFinishClick = {},
+            onMapClick = {},
+            onNotificationPermissionConfirm = {},
+            onNotificationPermissionDismiss = {}
         )
     }
 }

--- a/app/src/main/java/com/kiero/presentation/kid/journey/state/KidJourneyContract.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/state/KidJourneyContract.kt
@@ -13,23 +13,21 @@ data class KidJourneyState(
     val header: KidJourneyHeaderUiModel? = null,
     val content: KidJourneyContentUiModel = KidJourneyContentUiModel.NoSchedule,
     val permissionCameraDeniedCount: Int = 0,
+    val permissionNotificationDeniedCount: Int = 0,
+    val showNotificationPermissionDialog: Boolean = false,
 ) {
-
-    // 버튼 타입
     val buttonType: KidJourneyButtonType
         get() = when (content) {
             is KidJourneyContentUiModel.ScheduledContent -> {
-                if (content.isNowScheduleVerified) {
-                    KidJourneyButtonType.NONE
-                } else {
-                    KidJourneyButtonType.AUTH
+                when {
+                    content.isNowScheduleVerified -> KidJourneyButtonType.NONE
+                    else -> KidJourneyButtonType.AUTH
                 }
             }
             is KidJourneyContentUiModel.FireNotLit -> KidJourneyButtonType.FIRE
             else -> KidJourneyButtonType.NONE
         }
 
-    // 버튼 텍스트 리소스 ID
     val buttonTextRes: Int?
         get() = when (buttonType) {
             KidJourneyButtonType.AUTH -> R.string.journey_btn_auth
@@ -37,15 +35,22 @@ data class KidJourneyState(
             KidJourneyButtonType.NONE -> null
         }
 
-    // 다음 일정 버튼 활성화
     val shouldShowNextButton: Boolean
         get() = (content as? KidJourneyContentUiModel.ScheduledContent)?.isSkippable ?: false
 
-    // 일정 정보 표시 여부
+    val shouldShowFinishButton: Boolean
+        get() {
+            val scheduledContent = content as? KidJourneyContentUiModel.ScheduledContent ?: return false
+            val h = header ?: return false
+            return !scheduledContent.isSkippable
+                    && h.totalScheduleCount != null
+                    && h.totalScheduleCount > 0
+                    && scheduledContent.scheduleInfo.order == h.totalScheduleCount
+        }
+
     val shouldShowSchedule: Boolean
         get() = content is KidJourneyContentUiModel.ScheduledContent
 
-    //  스케줄 정보
     val currentScheduleInfo: KidJourneyScheduleUiModel?
         get() = (content as? KidJourneyContentUiModel.ScheduledContent)?.scheduleInfo
 

--- a/app/src/main/java/com/kiero/presentation/kid/journey/viewmodel/KidJourneyViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/viewmodel/KidJourneyViewModel.kt
@@ -24,9 +24,11 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -80,11 +82,50 @@ class KidJourneyViewModel @Inject constructor(
     init {
         sseManager.startChildSubscription()
         collectChildKidScheduleEvents()
+        observeNotificationDeniedCount()
     }
 
     fun fetchData() {
         fetchTodaySchedule()
         fetchCoin()
+    }
+
+    fun checkNotificationPermission(isAlreadyGranted: Boolean) {
+        if (isAlreadyGranted) return
+
+        viewModelScope.launch {
+            val deniedCount = permissionInfoManager.deniedCount(PermissionType.POST_NOTIFICATIONS).first()
+            if (deniedCount == 0) {
+                _state.update { uiState ->
+                    if (uiState is UiState.Success) {
+                        UiState.Success(uiState.data.copy(showNotificationPermissionDialog = true))
+                    } else uiState
+                }
+            }
+        }
+    }
+
+    fun onNotificationPermissionDialogDismiss() {
+        viewModelScope.launch {
+            permissionInfoManager.increaseDeniedCount(PermissionType.POST_NOTIFICATIONS)
+            _state.update { uiState ->
+                if (uiState is UiState.Success) {
+                    UiState.Success(uiState.data.copy(showNotificationPermissionDialog = false))
+                } else uiState
+            }
+        }
+    }
+
+    private fun observeNotificationDeniedCount() {
+        viewModelScope.launch {
+            permissionInfoManager.deniedCount(PermissionType.POST_NOTIFICATIONS).collect { count ->
+                _state.update { uiState ->
+                    if (uiState is UiState.Success) {
+                        UiState.Success(uiState.data.copy(permissionNotificationDeniedCount = count))
+                    } else uiState
+                }
+            }
+        }
     }
 
     private fun collectChildKidScheduleEvents() {
@@ -109,6 +150,7 @@ class KidJourneyViewModel @Inject constructor(
         viewModelScope.launch {
             repository.patchScheduleToday()
                 .onSuccess { scheduleData ->
+                    val currentDeniedCount = (_state.value as? UiState.Success)?.data?.permissionNotificationDeniedCount ?: 0
                     val stoneType = scheduleData.stoneType?.let { KidJourneyStoneType.from(it) }
                     val scheduleInfo = KidJourneyScheduleUiModel(
                         order = scheduleData.scheduleOrder,
@@ -118,6 +160,7 @@ class KidJourneyViewModel @Inject constructor(
 
                     _state.value = UiState.Success(
                         KidJourneyState(
+                            permissionNotificationDeniedCount = currentDeniedCount,
                             header = KidJourneyHeaderUiModel(
                                 kidName = coin.value.firstName,
                                 currentDate = coin.value.today,
@@ -173,7 +216,6 @@ class KidJourneyViewModel @Inject constructor(
 
     fun onNextClick() {
         val content = _state.value.successData?.content
-
         val scheduleDetailId =
             (content as? KidJourneyContentUiModel.ScheduledContent)?.scheduleDetailId
 

--- a/app/src/main/java/com/kiero/presentation/kid/journey/viewmodel/KidJourneyViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/journey/viewmodel/KidJourneyViewModel.kt
@@ -150,7 +150,7 @@ class KidJourneyViewModel @Inject constructor(
         viewModelScope.launch {
             repository.patchScheduleToday()
                 .onSuccess { scheduleData ->
-                    val currentDeniedCount = (_state.value as? UiState.Success)?.data?.permissionNotificationDeniedCount ?: 0
+                    val currentDeniedCount = _state.value.successData?.permissionNotificationDeniedCount ?: 0
                     val stoneType = scheduleData.stoneType?.let { KidJourneyStoneType.from(it) }
                     val scheduleInfo = KidJourneyScheduleUiModel(
                         order = scheduleData.scheduleOrder,


### PR DESCRIPTION
## ISSUE
- closed #171

## ❗ WORK DESCRIPTION
여정 끝내기
- 마지막 여정에서 "다음 여정으로" 대신 "여정 끝내기" 버튼 노출
- "여정 끝내기" 클릭 시 확인 팝업("오늘의 여정을 끝낼거야?") 표시
- 확인 시 기존 skipJourney API 호출 → fireNotLit 상태로 전환

최초 알림 권한 요청 팝업
- 오늘의 여정 최초 진입 시, OS 알림 권한이 없을 때 팝업 노출
- "알림받기" 버튼 클릭 시 → OS 알림 권한 요청


## 📢 TO REVIEWERS
- 리뷰어에게 전달해야 하는 말

## 📸 SCREENSHOT
<video src="https://github.com/user-attachments/assets/bba100a3-8817-4292-b2ab-d1d6a0bf37bb" witdh="300"/>


