### PR TITLE
[feat/#169] SP2 부모 마이페이지 API 구현 및 고도화

### DIFF
--- a/app/src/main/java/com/kiero/core/common/extension/ModifierExt.kt
+++ b/app/src/main/java/com/kiero/core/common/extension/ModifierExt.kt
@@ -28,6 +28,8 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.Velocity
@@ -126,66 +128,26 @@ fun Modifier.disableNestedScroll(): Modifier = composed {
     this.nestedScroll(connection)
 }
 
-// 위로 드래그 막는 함수 - 스크롤이 발생하기 전에 위로 올리는 행동 자체를 사전에 차단
-fun Modifier.disableUpScroll(): Modifier = composed {
-    val connection = remember {
-        object : NestedScrollConnection {
-            override fun onPreScroll(
-                available: Offset,
-                source: NestedScrollSource
-            ): Offset {
-                return if (available.y < 0) available else Offset.Zero
-            }
+/**
+ * 바텀시트 내부에서 위로 당기는(Upward) 드래그, 스크롤 이벤트만 가로채서 소비하는 Modifier
+ */
+fun Modifier.disableUpWardEvent(): Modifier = this.pointerInput(Unit) {
+    awaitPointerEventScope {
+        while (true) {
+            val event = awaitPointerEvent(PointerEventPass.Main)
 
-            override suspend fun onPreFling(available: Velocity): Velocity {
-                return if (available.y < 0) {
-                    val maxUpwardVelocity = -1000f
+            event.changes.forEach { change ->
+                if (!change.isConsumed) {
+                    val dy = change.position.y - change.previousPosition.y
 
-                    // 위로 튕기는 속도가 너무 강할 때
-                    if (available.y < maxUpwardVelocity) {
-                        Velocity(x = 0f, y = available.y - maxUpwardVelocity)
-                    } else {
-                        Velocity.Zero
+                    // 손가락이 위로 향할 때만 차단
+                    if (dy < 0) {
+                        change.consume()
                     }
-                } else {
-                    Velocity.Zero
                 }
             }
         }
     }
-    this.nestedScroll(connection)
-}
-
-// 자식에 LazyColumn 과 같은 스크롤 컴포넌트가 존재하는 경우 바텀시트가 튕기는 현상 방지
-fun Modifier.disableUpSheetScroll(): Modifier = composed {
-    val connection = remember {
-        object : NestedScrollConnection {
-            override fun onPostScroll(
-                consumed: Offset,
-                available: Offset,
-                source: NestedScrollSource
-            ): Offset {
-                return if (available.y < 0) available else Offset.Zero
-            }
-
-            override suspend fun onPostFling(
-                consumed: Velocity,
-                available: Velocity
-            ): Velocity {
-                return if (available.y < 0) {
-                    val maxUpwardVelocity = -500f
-                    if (available.y < maxUpwardVelocity) {
-                        Velocity(x = 0f, y = available.y - maxUpwardVelocity)
-                    } else {
-                        Velocity.Zero
-                    }
-                } else {
-                    Velocity.Zero
-                }
-            }
-        }
-    }
-    this.nestedScroll(connection)
 }
 
 

--- a/app/src/main/java/com/kiero/core/designsystem/component/bottomsheet/KieroBottomSheet.kt
+++ b/app/src/main/java/com/kiero/core/designsystem/component/bottomsheet/KieroBottomSheet.kt
@@ -1,6 +1,5 @@
 package com.kiero.core.designsystem.component.bottomsheet
 
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
@@ -8,7 +7,6 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.pointerInput
 import com.kiero.core.designsystem.theme.KieroTheme
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/kiero/core/localstorage/constant/DataStoreConstant.kt
+++ b/app/src/main/java/com/kiero/core/localstorage/constant/DataStoreConstant.kt
@@ -1,6 +1,7 @@
 package com.kiero.core.localstorage.constant
 
 import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 
 object DataStoreConstant {
@@ -11,12 +12,43 @@ object DataStoreConstant {
     // User Info
     val KEY_USER_ROLE = stringPreferencesKey("user_role")
     val KEY_IS_SAW_ONBOARDING = booleanPreferencesKey("is_saw_onboarding")
-
     val KEY_PARENT_NAME = stringPreferencesKey("parent_name")
     val KEY_PARENT_PROFILE_IMAGE = stringPreferencesKey("parent_profile_image")
-
     val KEY_CHILD_ID = stringPreferencesKey("child_id")
+    val KEY_CHILD_LAST_NAME = stringPreferencesKey("key_child_last_name")
+    val KEY_CHILD_FIRST_NAME = stringPreferencesKey("key_child_first_name")
+    val KEY_PENDING_INVITE_CODE = stringPreferencesKey("key_pending_invite_code")
+    val KEY_PENDING_INVITE_EXPIRE_TIME = longPreferencesKey("key_pending_invite_expire_time")
 
     // Permission
     const val KEY_PERMISSION_DENIED_COUNT = "permission_denied_count"
+
+    // Terms
+    val KEY_IS_REQUIRED_TERMS_ALL_AGREED = booleanPreferencesKey("is_required_terms_all_agreed")
+    val KEY_AGREED_TERMS_IDS = stringPreferencesKey("agreed_terms_ids")
+
+    // key 그룹핑
+    val TOKEN_KEYS = listOf(
+        KEY_ACCESS_TOKEN,
+        KEY_REFRESH_TOKEN
+    )
+
+    val PARENT_INFO_KEYS = listOf(
+        KEY_USER_ROLE,
+        KEY_PARENT_NAME,
+        KEY_PARENT_PROFILE_IMAGE,
+        KEY_CHILD_ID,
+        KEY_CHILD_LAST_NAME,
+        KEY_CHILD_FIRST_NAME,
+        KEY_PENDING_INVITE_CODE,
+        KEY_PENDING_INVITE_EXPIRE_TIME,
+        KEY_IS_REQUIRED_TERMS_ALL_AGREED,
+        KEY_AGREED_TERMS_IDS,
+    )
+
+    val CHILD_INFO_KEYS = listOf(
+        KEY_USER_ROLE,
+        KEY_IS_SAW_ONBOARDING,
+    )
+
 }

--- a/app/src/main/java/com/kiero/core/localstorage/info/UserInfoManager.kt
+++ b/app/src/main/java/com/kiero/core/localstorage/info/UserInfoManager.kt
@@ -10,4 +10,26 @@ interface UserInfoManager {
 
     suspend fun saveChildIdInfo(childId : Long)
     suspend fun getChildIdInfo(): Long?
+
+    /**
+     * 필수 약관 동의 여부 저장
+     * */
+    suspend fun saveTermsInfo(isRequiredTermsAllAgreed: Boolean)
+
+    suspend fun getTermsInfo(): Boolean?
+
+    suspend fun saveAgreedTermsIds(termsIds: List<Long>)
+    suspend fun getAgreedTermsIds(): List<Long>?
+
+    /**
+    * 자녀 정보 - 발급 코드, 남은 시간 등
+    * */
+    suspend fun saveChildName(lastName: String, firstName: String)
+    suspend fun getChildLastName(): String?
+    suspend fun getChildFirstName(): String?
+
+    suspend fun savePendingInviteCode(code: String, expireTimeMillis: Long)
+    suspend fun getPendingInviteCode(): String?
+    suspend fun getPendingInviteExpireTime(): Long
+    suspend fun clearPendingInviteCode()
 }

--- a/app/src/main/java/com/kiero/core/localstorage/info/UserInfoManager.kt
+++ b/app/src/main/java/com/kiero/core/localstorage/info/UserInfoManager.kt
@@ -7,6 +7,7 @@ interface UserInfoManager {
     suspend fun getParentInfo(): ParentInfo?
 
     suspend fun clearParentInfo()
+    suspend fun clearKidInfo()
 
     suspend fun saveChildIdInfo(childId : Long)
     suspend fun getChildIdInfo(): Long?

--- a/app/src/main/java/com/kiero/core/localstorage/info/UserInfoManagerImpl.kt
+++ b/app/src/main/java/com/kiero/core/localstorage/info/UserInfoManagerImpl.kt
@@ -75,6 +75,29 @@ class UserInfoManagerImpl @Inject constructor(
         }
     }
 
+    override suspend fun clearKidInfo() {
+        suspendRunCatching {
+            dataStore.edit { preferences ->
+                DataStoreConstant.CHILD_INFO_KEYS.forEach { key ->
+                    preferences.remove(key)
+                }
+
+                val dynamicPermissionKeys = preferences.asMap().keys.filter {
+                    it.name.startsWith(DataStoreConstant.KEY_PERMISSION_DENIED_COUNT)
+                }
+                dynamicPermissionKeys.forEach { key ->
+                    preferences.remove(key)
+                }
+
+                DataStoreConstant.TOKEN_KEYS.forEach { key ->
+                    preferences.remove(key)
+                }
+            }
+        }.onFailure {
+            Timber.e(it, "Failed to clear kid info")
+        }
+    }
+
     override suspend fun saveChildIdInfo(childId: Long) {
         suspendRunCatching {
             dataStore.edit { preferences ->

--- a/app/src/main/java/com/kiero/core/localstorage/info/UserInfoManagerImpl.kt
+++ b/app/src/main/java/com/kiero/core/localstorage/info/UserInfoManagerImpl.kt
@@ -4,9 +4,16 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import com.kiero.core.common.util.suspendRunCatching
+import com.kiero.core.localstorage.constant.DataStoreConstant
+import com.kiero.core.localstorage.constant.DataStoreConstant.KEY_AGREED_TERMS_IDS
+import com.kiero.core.localstorage.constant.DataStoreConstant.KEY_CHILD_FIRST_NAME
 import com.kiero.core.localstorage.constant.DataStoreConstant.KEY_CHILD_ID
+import com.kiero.core.localstorage.constant.DataStoreConstant.KEY_CHILD_LAST_NAME
+import com.kiero.core.localstorage.constant.DataStoreConstant.KEY_IS_REQUIRED_TERMS_ALL_AGREED
 import com.kiero.core.localstorage.constant.DataStoreConstant.KEY_PARENT_NAME
 import com.kiero.core.localstorage.constant.DataStoreConstant.KEY_PARENT_PROFILE_IMAGE
+import com.kiero.core.localstorage.constant.DataStoreConstant.KEY_PENDING_INVITE_CODE
+import com.kiero.core.localstorage.constant.DataStoreConstant.KEY_PENDING_INVITE_EXPIRE_TIME
 import com.kiero.core.model.parent.ParentInfo
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -48,8 +55,20 @@ class UserInfoManagerImpl @Inject constructor(
     override suspend fun clearParentInfo() {
         suspendRunCatching {
             dataStore.edit { preferences ->
-                preferences.remove(KEY_PARENT_NAME)
-                preferences.remove(KEY_PARENT_PROFILE_IMAGE)
+                DataStoreConstant.PARENT_INFO_KEYS.forEach { key ->
+                    preferences.remove(key)
+                }
+
+                val dynamicPermissionKeys = preferences.asMap().keys.filter {
+                    it.name.startsWith(DataStoreConstant.KEY_PERMISSION_DENIED_COUNT)
+                }
+                dynamicPermissionKeys.forEach { key ->
+                    preferences.remove(key)
+                }
+
+                DataStoreConstant.TOKEN_KEYS.forEach { key ->
+                    preferences.remove(key)
+                }
             }
         }.onFailure {
             Timber.e(it, "Failed to clear parent info")
@@ -75,5 +94,117 @@ class UserInfoManagerImpl @Inject constructor(
         }.onFailure {
             Timber.e(it, "Failed to get child id info")
         }.getOrNull()
+    }
+
+    override suspend fun saveTermsInfo(isRequiredTermsAllAgreed: Boolean) {
+        suspendRunCatching {
+            dataStore.edit { preferences ->
+                preferences[KEY_IS_REQUIRED_TERMS_ALL_AGREED] = isRequiredTermsAllAgreed
+            }
+        }.onFailure {
+            Timber.e(it, "Failed to save terms info")
+        }
+    }
+
+    override suspend fun getTermsInfo(): Boolean? {
+        return suspendRunCatching {
+            dataStore.data.map { preferences ->
+                preferences[KEY_IS_REQUIRED_TERMS_ALL_AGREED]
+            }.first()
+        }.onFailure {
+            Timber.e(it, "Failed to get terms info")
+        }.getOrNull()
+    }
+
+    override suspend fun saveAgreedTermsIds(termsIds: List<Long>) {
+        suspendRunCatching {
+            dataStore.edit { preferences ->
+                preferences[KEY_AGREED_TERMS_IDS] = termsIds.joinToString(",")
+            }
+        }.onFailure {
+            Timber.e(it, "Failed to save agreed terms ids")
+        }
+    }
+
+    override suspend fun getAgreedTermsIds(): List<Long>? {
+        return suspendRunCatching {
+            dataStore.data.map { preferences ->
+                val agreedTermsIds = preferences[KEY_AGREED_TERMS_IDS]
+                agreedTermsIds?.split(",")?.map { it.toLong() }
+            }.first()
+        }.onFailure {
+            Timber.e(it, "Failed to get agreed terms ids")
+        }.getOrNull()
+    }
+
+    override suspend fun saveChildName(lastName: String, firstName: String) {
+        suspendRunCatching {
+            dataStore.edit { preferences ->
+                preferences[KEY_CHILD_LAST_NAME] = lastName
+                preferences[KEY_CHILD_FIRST_NAME] = firstName
+            }
+        }.onFailure {
+            Timber.e(it, "Failed to save child name")
+        }
+    }
+
+    override suspend fun getChildLastName(): String? {
+        return suspendRunCatching {
+            dataStore.data.map { preferences ->
+                preferences[KEY_CHILD_LAST_NAME]
+            }.first()
+        }.onFailure {
+            Timber.e(it, "Failed to get child last name")
+        }.getOrNull()
+    }
+
+    override suspend fun getChildFirstName(): String? {
+        return suspendRunCatching {
+            dataStore.data.map { preferences ->
+                preferences[KEY_CHILD_FIRST_NAME]
+            }.first()
+        }.onFailure {
+            Timber.e(it, "Failed to get child first name")
+        }.getOrNull()
+    }
+
+    override suspend fun savePendingInviteCode(code: String, expireTimeMillis: Long) {
+        suspendRunCatching {
+            dataStore.edit { preferences ->
+                preferences[KEY_PENDING_INVITE_CODE] = code
+                preferences[KEY_PENDING_INVITE_EXPIRE_TIME] = expireTimeMillis
+            }
+        }.onFailure {
+            Timber.e(it, "Failed to save pending invite code")
+        }
+    }
+
+    override suspend fun getPendingInviteCode(): String? {
+        return suspendRunCatching {
+            dataStore.data.map { preferences ->
+                preferences[KEY_PENDING_INVITE_CODE]
+            }.first()
+        }.onFailure {
+            Timber.e(it, "Failed to get pending invite code")
+        }.getOrNull()
+    }
+
+    override suspend fun getPendingInviteExpireTime(): Long {
+        return suspendRunCatching {
+            dataStore.data.map { preferences ->
+                preferences[KEY_PENDING_INVITE_EXPIRE_TIME] ?: 0L
+            }.first()
+        }.getOrDefault(0L)
+    }
+
+    override suspend fun clearPendingInviteCode() {
+        suspendRunCatching {
+            dataStore.edit { preferences ->
+                preferences.remove(KEY_PENDING_INVITE_CODE)
+                preferences.remove(KEY_PENDING_INVITE_EXPIRE_TIME)
+            }
+        }.onFailure {
+            Timber.e(it, "Failed to clear pending invite code")
+        }
     }
 }

--- a/app/src/main/java/com/kiero/data/auth/remote/api/AuthService.kt
+++ b/app/src/main/java/com/kiero/data/auth/remote/api/AuthService.kt
@@ -9,8 +9,10 @@ import retrofit2.http.POST
 import retrofit2.http.Query
 
 interface AuthService {
-    // 부모
-    @POST("api/v1/parents/login/access-token")
+    /**
+     * 부모 카카오 로그인
+     * */
+    @POST("api/v1/parents/login/kakao/access-token")
     suspend fun postAuthLogin(
         @Query("accessToken") accessToken: String
     ): BaseResponse<AuthLoginResponseDto>

--- a/app/src/main/java/com/kiero/data/parent/mypage/kid/di/KidMyPageDataSourceModule.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/kid/di/KidMyPageDataSourceModule.kt
@@ -1,0 +1,19 @@
+package com.kiero.data.parent.mypage.kid.di
+
+import com.kiero.data.parent.mypage.kid.remote.datasource.KidMyPageDataSource
+import com.kiero.data.parent.mypage.kid.remote.datasourceimpl.KidMyPageDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class KidMyPageDataSourceModule {
+    @Binds
+    @Singleton
+    abstract fun bindKidMyPageDataSource(
+        kidMyPageDataSourceImpl: KidMyPageDataSourceImpl
+    ): KidMyPageDataSource
+}

--- a/app/src/main/java/com/kiero/data/parent/mypage/kid/di/KidMyPageRepositoryModule.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/kid/di/KidMyPageRepositoryModule.kt
@@ -1,0 +1,20 @@
+package com.kiero.data.parent.mypage.kid.di
+
+import com.kiero.data.parent.mypage.kid.repository.KidMyPageRepository
+import com.kiero.data.parent.mypage.kid.repositoryimpl.KidMyPageRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface KidMyPageRepositoryModule {
+
+    @Binds
+    @Singleton
+    fun bindKidMyPageRepository(
+        kidMyPageRepositoryImpl: KidMyPageRepositoryImpl
+    ): KidMyPageRepository
+}

--- a/app/src/main/java/com/kiero/data/parent/mypage/kid/di/KidMyPageServiceModule.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/kid/di/KidMyPageServiceModule.kt
@@ -1,0 +1,23 @@
+package com.kiero.data.parent.mypage.kid.di
+
+import com.kiero.core.network.di.AuthNetwork
+import com.kiero.data.parent.mypage.kid.remote.api.KidMyPageService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.create
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object KidMyPageServiceModule {
+    @Provides
+    @Singleton
+    fun provideKidMyPageService(
+        @AuthNetwork retrofit: Retrofit
+    ): KidMyPageService {
+        return retrofit.create()
+    }
+}

--- a/app/src/main/java/com/kiero/data/parent/mypage/kid/model/KidTermsModel.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/kid/model/KidTermsModel.kt
@@ -1,0 +1,13 @@
+package com.kiero.data.parent.mypage.kid.model
+
+import com.kiero.data.parent.mypage.kid.remote.dto.response.KidTermResponseDto
+
+data class KidTermsModel(
+    val linkType: String,
+    val link: String
+)
+
+fun KidTermResponseDto.toModel() = KidTermsModel(
+    linkType = linkType,
+    link = link
+)

--- a/app/src/main/java/com/kiero/data/parent/mypage/kid/remote/api/KidMyPageService.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/kid/remote/api/KidMyPageService.kt
@@ -1,0 +1,13 @@
+package com.kiero.data.parent.mypage.kid.remote.api
+
+import com.kiero.core.network.model.BaseResponse
+import com.kiero.data.parent.mypage.kid.remote.dto.response.KidTermResponseDto
+import retrofit2.http.GET
+
+interface KidMyPageService {
+    /**
+     * 아이 마이페이지 외부 링크 조회
+     * */
+    @GET("api/v1/terms/children")
+    suspend fun getKidTermsExternalLink(): BaseResponse<List<KidTermResponseDto>>
+}

--- a/app/src/main/java/com/kiero/data/parent/mypage/kid/remote/datasource/KidMyPageDataSource.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/kid/remote/datasource/KidMyPageDataSource.kt
@@ -1,0 +1,8 @@
+package com.kiero.data.parent.mypage.kid.remote.datasource
+
+import com.kiero.core.network.model.BaseResponse
+import com.kiero.data.parent.mypage.kid.remote.dto.response.KidTermResponseDto
+
+interface KidMyPageDataSource {
+    suspend fun getKidTermsExternalLink(): BaseResponse<List<KidTermResponseDto>>
+}

--- a/app/src/main/java/com/kiero/data/parent/mypage/kid/remote/datasourceimpl/KidMyPageDataSourceImpl.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/kid/remote/datasourceimpl/KidMyPageDataSourceImpl.kt
@@ -1,0 +1,14 @@
+package com.kiero.data.parent.mypage.kid.remote.datasourceimpl
+
+import com.kiero.core.network.model.BaseResponse
+import com.kiero.data.parent.mypage.kid.remote.api.KidMyPageService
+import com.kiero.data.parent.mypage.kid.remote.datasource.KidMyPageDataSource
+import com.kiero.data.parent.mypage.kid.remote.dto.response.KidTermResponseDto
+import javax.inject.Inject
+
+class KidMyPageDataSourceImpl @Inject constructor(
+    private val kidMyPageService: KidMyPageService
+): KidMyPageDataSource {
+    override suspend fun getKidTermsExternalLink(): BaseResponse<List<KidTermResponseDto>> =
+        kidMyPageService.getKidTermsExternalLink()
+}

--- a/app/src/main/java/com/kiero/data/parent/mypage/kid/remote/dto/response/KidTermResponseDto.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/kid/remote/dto/response/KidTermResponseDto.kt
@@ -1,0 +1,12 @@
+package com.kiero.data.parent.mypage.kid.remote.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class KidTermResponseDto(
+    @SerialName("linkType")
+    val linkType: String,
+    @SerialName("link")
+    val link: String
+)

--- a/app/src/main/java/com/kiero/data/parent/mypage/kid/repository/KidMyPageRepository.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/kid/repository/KidMyPageRepository.kt
@@ -1,0 +1,7 @@
+package com.kiero.data.parent.mypage.kid.repository
+
+import com.kiero.data.parent.mypage.kid.model.KidTermsModel
+
+interface KidMyPageRepository {
+    suspend fun getKidTermsExternalLink(): Result<List<KidTermsModel>>
+}

--- a/app/src/main/java/com/kiero/data/parent/mypage/kid/repositoryimpl/KidMyPageRepositoryImpl.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/kid/repositoryimpl/KidMyPageRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package com.kiero.data.parent.mypage.kid.repositoryimpl
+
+import com.kiero.core.common.util.suspendRunCatching
+import com.kiero.data.parent.mypage.kid.model.KidTermsModel
+import com.kiero.data.parent.mypage.kid.model.toModel
+import com.kiero.data.parent.mypage.kid.remote.datasource.KidMyPageDataSource
+import com.kiero.data.parent.mypage.kid.repository.KidMyPageRepository
+import javax.inject.Inject
+
+class KidMyPageRepositoryImpl @Inject constructor(
+    private val kidMyPageDataSource: KidMyPageDataSource
+) : KidMyPageRepository {
+    override suspend fun getKidTermsExternalLink(): Result<List<KidTermsModel>> = suspendRunCatching {
+        kidMyPageDataSource.getKidTermsExternalLink().data!!.map { it.toModel() }
+    }
+}

--- a/app/src/main/java/com/kiero/data/parent/mypage/parent/di/ParentMyPageDataSourceModule.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/parent/di/ParentMyPageDataSourceModule.kt
@@ -1,0 +1,19 @@
+package com.kiero.data.parent.mypage.parent.di
+
+import com.kiero.data.parent.mypage.parent.remote.datasource.ParentMyPageDataSource
+import com.kiero.data.parent.mypage.parent.remote.datasourceimpl.ParentMyPageDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ParentMyPageDataSourceModule {
+    @Binds
+    @Singleton
+    abstract fun bindParentMyPageDataSource(
+        parentMyPageDataSourceImpl: ParentMyPageDataSourceImpl
+    ): ParentMyPageDataSource
+}

--- a/app/src/main/java/com/kiero/data/parent/mypage/parent/di/ParentMyPageRepositoryModule.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/parent/di/ParentMyPageRepositoryModule.kt
@@ -1,0 +1,19 @@
+package com.kiero.data.parent.mypage.parent.di
+
+import com.kiero.data.parent.mypage.parent.repository.ParentMyPageRepository
+import com.kiero.data.parent.mypage.parent.repositoryimpl.ParentMyPageRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface ParentMyPageRepositoryModule {
+    @Binds
+    @Singleton
+    fun bindParentMyPageRepository(
+        parentMyPageRepositoryImpl: ParentMyPageRepositoryImpl
+    ): ParentMyPageRepository
+}

--- a/app/src/main/java/com/kiero/data/parent/mypage/parent/di/ParentMyPageServiceModule.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/parent/di/ParentMyPageServiceModule.kt
@@ -1,0 +1,21 @@
+package com.kiero.data.parent.mypage.parent.di
+
+import com.kiero.core.network.di.AuthNetwork
+import com.kiero.data.parent.mypage.parent.remote.api.ParentMyPageService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.create
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ParentMyPageServiceModule {
+    @Provides
+    @Singleton
+    fun provideParentMyPageService(
+        @AuthNetwork retrofit: Retrofit,
+    ): ParentMyPageService = retrofit.create()
+}

--- a/app/src/main/java/com/kiero/data/parent/mypage/parent/model/ParentMyProfileModel.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/parent/model/ParentMyProfileModel.kt
@@ -1,0 +1,17 @@
+package com.kiero.data.parent.mypage.parent.model
+
+import com.kiero.data.parent.mypage.parent.remote.dto.response.parent.ParentMyProfileResponseDto
+
+data class ParentMyProfileModel(
+    val image: String?,
+    val name: String,
+    val hasPendingChildSession: Boolean,
+    val pushNotificationEnabled: Boolean
+)
+
+fun ParentMyProfileResponseDto.toModel() = ParentMyProfileModel(
+    image = image,
+    name = name,
+    hasPendingChildSession = hasPendingChildSession,
+    pushNotificationEnabled = pushNotificationEnabled
+)

--- a/app/src/main/java/com/kiero/data/parent/mypage/parent/model/ParentTermsModel.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/parent/model/ParentTermsModel.kt
@@ -1,0 +1,13 @@
+package com.kiero.data.parent.mypage.parent.model
+
+import com.kiero.data.parent.mypage.parent.remote.dto.response.parent.ParentTermResponseDto
+
+data class ParentTermsModel(
+    val linkType: String,
+    val link: String
+)
+
+fun ParentTermResponseDto.toModel() = ParentTermsModel(
+    linkType = linkType,
+    link = link
+)

--- a/app/src/main/java/com/kiero/data/parent/mypage/parent/remote/api/ParentMyPageService.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/parent/remote/api/ParentMyPageService.kt
@@ -1,0 +1,29 @@
+package com.kiero.data.parent.mypage.parent.remote.api
+
+import com.kiero.core.network.model.BaseResponse
+import com.kiero.data.parent.mypage.parent.remote.dto.response.parent.ParentMyProfileResponseDto
+import com.kiero.data.parent.mypage.parent.remote.dto.response.parent.ParentTermResponseDto
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface ParentMyPageService {
+    // 부모
+    /**
+     * 부모 프로필 정보 조회
+     * */
+    @GET("api/v1/parents/me")
+    suspend fun getParentMyProfile(): BaseResponse<ParentMyProfileResponseDto>
+
+    /**
+     * 부모 마이페이지 외부링크 조회
+     * */
+    @GET("api/v1/terms/parent")
+    suspend fun getParentTermsExternalLink(): BaseResponse<List<ParentTermResponseDto>>
+
+    /**
+     * 부모 탈퇴
+     * */
+    @POST("api/v1/parents/withdraw")
+    suspend fun postWithdrawStatus(): Response<Unit>
+}

--- a/app/src/main/java/com/kiero/data/parent/mypage/parent/remote/datasource/ParentMyPageDataSource.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/parent/remote/datasource/ParentMyPageDataSource.kt
@@ -1,0 +1,12 @@
+package com.kiero.data.parent.mypage.parent.remote.datasource
+
+import com.kiero.core.network.model.BaseResponse
+import com.kiero.data.parent.mypage.parent.remote.dto.response.parent.ParentMyProfileResponseDto
+import com.kiero.data.parent.mypage.parent.remote.dto.response.parent.ParentTermResponseDto
+import retrofit2.Response
+
+interface ParentMyPageDataSource {
+    suspend fun getParentMyProfile(): BaseResponse<ParentMyProfileResponseDto>
+    suspend fun getParentTermsExternalLink(): BaseResponse<List<ParentTermResponseDto>>
+    suspend fun postWithdrawStatus(): Response<Unit>
+}

--- a/app/src/main/java/com/kiero/data/parent/mypage/parent/remote/datasourceimpl/ParentMyPageDataSourceImpl.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/parent/remote/datasourceimpl/ParentMyPageDataSourceImpl.kt
@@ -1,0 +1,23 @@
+package com.kiero.data.parent.mypage.parent.remote.datasourceimpl
+
+import com.kiero.core.network.di.AuthNetwork
+import com.kiero.core.network.model.BaseResponse
+import com.kiero.data.parent.mypage.parent.remote.api.ParentMyPageService
+import com.kiero.data.parent.mypage.parent.remote.datasource.ParentMyPageDataSource
+import com.kiero.data.parent.mypage.parent.remote.dto.response.parent.ParentMyProfileResponseDto
+import com.kiero.data.parent.mypage.parent.remote.dto.response.parent.ParentTermResponseDto
+import retrofit2.Response
+import javax.inject.Inject
+
+class ParentMyPageDataSourceImpl @Inject constructor(
+    private val parentMyPageService: ParentMyPageService
+): ParentMyPageDataSource {
+    override suspend fun getParentMyProfile(): BaseResponse<ParentMyProfileResponseDto> =
+        parentMyPageService.getParentMyProfile()
+
+    override suspend fun getParentTermsExternalLink(): BaseResponse<List<ParentTermResponseDto>> =
+        parentMyPageService.getParentTermsExternalLink()
+
+    override suspend fun postWithdrawStatus(): Response<Unit> =
+        parentMyPageService.postWithdrawStatus()
+}

--- a/app/src/main/java/com/kiero/data/parent/mypage/parent/remote/dto/response/parent/ParentMyProfileResponseDto.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/parent/remote/dto/response/parent/ParentMyProfileResponseDto.kt
@@ -1,0 +1,16 @@
+package com.kiero.data.parent.mypage.parent.remote.dto.response.parent
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ParentMyProfileResponseDto(
+    @SerialName("image")
+    val image: String?,
+    @SerialName("name")
+    val name: String,
+    @SerialName("hasPendingChildSession")
+    val hasPendingChildSession: Boolean,
+    @SerialName("pushNotificationEnabled")
+    val pushNotificationEnabled: Boolean
+)

--- a/app/src/main/java/com/kiero/data/parent/mypage/parent/remote/dto/response/parent/ParentTermResponseDto.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/parent/remote/dto/response/parent/ParentTermResponseDto.kt
@@ -1,0 +1,12 @@
+package com.kiero.data.parent.mypage.parent.remote.dto.response.parent
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ParentTermResponseDto(
+    @SerialName("linkType")
+    val linkType: String,
+    @SerialName("link")
+    val link: String
+)

--- a/app/src/main/java/com/kiero/data/parent/mypage/parent/repository/ParentMyPageRepository.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/parent/repository/ParentMyPageRepository.kt
@@ -1,0 +1,10 @@
+package com.kiero.data.parent.mypage.parent.repository
+
+import com.kiero.data.parent.mypage.parent.model.ParentMyProfileModel
+import com.kiero.data.parent.mypage.parent.model.ParentTermsModel
+
+interface ParentMyPageRepository {
+    suspend fun getParentMyProfile(): Result<ParentMyProfileModel>
+    suspend fun getParentTermsExternalLink(): Result<List<ParentTermsModel>>
+    suspend fun postWithdrawStatus(): Result<Unit>
+}

--- a/app/src/main/java/com/kiero/data/parent/mypage/parent/repositoryimpl/ParentMyPageRepositoryImpl.kt
+++ b/app/src/main/java/com/kiero/data/parent/mypage/parent/repositoryimpl/ParentMyPageRepositoryImpl.kt
@@ -1,0 +1,25 @@
+package com.kiero.data.parent.mypage.parent.repositoryimpl
+
+import com.kiero.core.common.util.suspendRunCatching
+import com.kiero.data.parent.mypage.parent.model.ParentMyProfileModel
+import com.kiero.data.parent.mypage.parent.model.ParentTermsModel
+import com.kiero.data.parent.mypage.parent.model.toModel
+import com.kiero.data.parent.mypage.parent.remote.datasource.ParentMyPageDataSource
+import com.kiero.data.parent.mypage.parent.repository.ParentMyPageRepository
+import javax.inject.Inject
+
+class ParentMyPageRepositoryImpl @Inject constructor(
+    private val parentMyPageDataSource: ParentMyPageDataSource
+) : ParentMyPageRepository {
+    override suspend fun getParentMyProfile(): Result<ParentMyProfileModel> = suspendRunCatching {
+        parentMyPageDataSource.getParentMyProfile().data!!.toModel()
+    }
+
+    override suspend fun getParentTermsExternalLink(): Result<List<ParentTermsModel>> = suspendRunCatching {
+        parentMyPageDataSource.getParentTermsExternalLink().data!!.map { it.toModel() }
+    }
+
+    override suspend fun postWithdrawStatus(): Result<Unit> = suspendRunCatching {
+        parentMyPageDataSource.postWithdrawStatus()
+    }
+}

--- a/app/src/main/java/com/kiero/data/terms/di/TermsDataSourceModule.kt
+++ b/app/src/main/java/com/kiero/data/terms/di/TermsDataSourceModule.kt
@@ -1,0 +1,19 @@
+package com.kiero.data.terms.di
+
+import com.kiero.data.terms.remote.datasource.TermsDataSource
+import com.kiero.data.terms.remote.datasourceimpl.TermsDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class TermsDataSourceModule {
+    @Binds
+    @Singleton
+    abstract fun bindTermsDataSource(
+        termsDataSourceImpl: TermsDataSourceImpl
+    ): TermsDataSource
+}

--- a/app/src/main/java/com/kiero/data/terms/di/TermsRepositoryModule.kt
+++ b/app/src/main/java/com/kiero/data/terms/di/TermsRepositoryModule.kt
@@ -1,0 +1,19 @@
+package com.kiero.data.terms.di
+
+import com.kiero.data.terms.repository.TermsRepository
+import com.kiero.data.terms.repositoryimpl.TermsRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface TermsRepositoryModule {
+    @Binds
+    @Singleton
+    fun bindTermsRepository(
+        termsRepositoryImpl: TermsRepositoryImpl
+    ): TermsRepository
+}

--- a/app/src/main/java/com/kiero/data/terms/di/TermsServiceModule.kt
+++ b/app/src/main/java/com/kiero/data/terms/di/TermsServiceModule.kt
@@ -1,0 +1,21 @@
+package com.kiero.data.terms.di
+
+import com.kiero.core.network.di.AuthNetwork
+import com.kiero.data.terms.remote.api.TermsService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.create
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object TermsServiceModule {
+    @Provides
+    @Singleton
+    fun provideTermsService(
+        @AuthNetwork retrofit: Retrofit,
+    ): TermsService = retrofit.create()
+}

--- a/app/src/main/java/com/kiero/data/terms/model/TermsAgreementModel.kt
+++ b/app/src/main/java/com/kiero/data/terms/model/TermsAgreementModel.kt
@@ -1,0 +1,11 @@
+package com.kiero.data.terms.model
+
+import com.kiero.data.terms.remote.dto.request.TermsAgreementRequestDto
+
+data class TermsAgreementModel(
+    val termsIds: List<Long>,
+) {
+    fun toDto() = TermsAgreementRequestDto(
+        termsIds = this.termsIds,
+    )
+}

--- a/app/src/main/java/com/kiero/data/terms/model/TermsItemModel.kt
+++ b/app/src/main/java/com/kiero/data/terms/model/TermsItemModel.kt
@@ -1,0 +1,15 @@
+package com.kiero.data.terms.model
+
+import com.kiero.data.terms.remote.dto.response.TermsItemResponseDto
+
+data class TermsItemModel(
+    val termsId: Long,
+    val termsType: String,
+    val url: String,
+)
+
+fun TermsItemResponseDto.toModel() = TermsItemModel(
+    termsId = this.termsId,
+    termsType = this.termsType,
+    url = this.url,
+)

--- a/app/src/main/java/com/kiero/data/terms/model/TermsStatusModel.kt
+++ b/app/src/main/java/com/kiero/data/terms/model/TermsStatusModel.kt
@@ -1,0 +1,11 @@
+package com.kiero.data.terms.model
+
+import com.kiero.data.terms.remote.dto.response.TermsAgreementResponseDto
+
+data class TermsStatusModel(
+    val isRequiredTermsAllAgreed: Boolean
+)
+
+fun TermsAgreementResponseDto.toModel() = TermsStatusModel(
+    isRequiredTermsAllAgreed = this.isRequiredTermsAllAgreed
+)

--- a/app/src/main/java/com/kiero/data/terms/remote/api/TermsService.kt
+++ b/app/src/main/java/com/kiero/data/terms/remote/api/TermsService.kt
@@ -1,0 +1,33 @@
+package com.kiero.data.terms.remote.api
+
+import com.kiero.core.network.model.BaseResponse
+import com.kiero.data.terms.remote.dto.request.TermsAgreementRequestDto
+import com.kiero.data.terms.remote.dto.response.TermsAgreementResponseDto
+import com.kiero.data.terms.remote.dto.response.TermsItemResponseDto
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface TermsService {
+    /**
+     * 필수 약관 동의 여부 조회
+     * */
+    @GET("api/v1/terms/required/status")
+    suspend fun getTermsStatus(): BaseResponse<TermsAgreementResponseDto>
+
+    /**
+     * 필수 약관 링크 조회
+     */
+    @GET("api/v1/terms/required")
+    suspend fun getTermsLink(): BaseResponse<List<TermsItemResponseDto>>
+
+
+    /**
+     * 필수 약관 등록 - 시작하기에서 호출하기
+     * */
+    @POST("api/v1/terms/required")
+    suspend fun postTermsStatus(
+        @Body request: TermsAgreementRequestDto
+    ): Response<Unit>
+}

--- a/app/src/main/java/com/kiero/data/terms/remote/datasource/TermsDataSource.kt
+++ b/app/src/main/java/com/kiero/data/terms/remote/datasource/TermsDataSource.kt
@@ -1,0 +1,15 @@
+package com.kiero.data.terms.remote.datasource
+
+import com.kiero.core.network.model.BaseResponse
+import com.kiero.data.terms.remote.dto.request.TermsAgreementRequestDto
+import com.kiero.data.terms.remote.dto.response.TermsAgreementResponseDto
+import com.kiero.data.terms.remote.dto.response.TermsItemResponseDto
+import retrofit2.Response
+
+interface TermsDataSource {
+    suspend fun getTermsStatus(): BaseResponse<TermsAgreementResponseDto>
+
+    suspend fun getTermsLink(): BaseResponse<List<TermsItemResponseDto>>
+
+    suspend fun postTermsStatus(request: TermsAgreementRequestDto): Response<Unit>
+}

--- a/app/src/main/java/com/kiero/data/terms/remote/datasourceimpl/TermsDataSourceImpl.kt
+++ b/app/src/main/java/com/kiero/data/terms/remote/datasourceimpl/TermsDataSourceImpl.kt
@@ -1,0 +1,22 @@
+package com.kiero.data.terms.remote.datasourceimpl
+
+import com.kiero.core.network.model.BaseResponse
+import com.kiero.data.terms.remote.api.TermsService
+import com.kiero.data.terms.remote.datasource.TermsDataSource
+import com.kiero.data.terms.remote.dto.request.TermsAgreementRequestDto
+import com.kiero.data.terms.remote.dto.response.TermsAgreementResponseDto
+import com.kiero.data.terms.remote.dto.response.TermsItemResponseDto
+import javax.inject.Inject
+
+class TermsDataSourceImpl @Inject constructor(
+    private val termsService: TermsService
+) : TermsDataSource {
+    override suspend fun getTermsStatus(): BaseResponse<TermsAgreementResponseDto> =
+        termsService.getTermsStatus()
+
+    override suspend fun getTermsLink(): BaseResponse<List<TermsItemResponseDto>> =
+        termsService.getTermsLink()
+
+    override suspend fun postTermsStatus(request: TermsAgreementRequestDto) =
+        termsService.postTermsStatus(request)
+}

--- a/app/src/main/java/com/kiero/data/terms/remote/dto/request/TermsAgreementRequestDto.kt
+++ b/app/src/main/java/com/kiero/data/terms/remote/dto/request/TermsAgreementRequestDto.kt
@@ -1,0 +1,10 @@
+package com.kiero.data.terms.remote.dto.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TermsAgreementRequestDto(
+    @SerialName("termsIds")
+    val termsIds: List<Long>
+)

--- a/app/src/main/java/com/kiero/data/terms/remote/dto/response/TermsAgreementResponseDto.kt
+++ b/app/src/main/java/com/kiero/data/terms/remote/dto/response/TermsAgreementResponseDto.kt
@@ -1,0 +1,10 @@
+package com.kiero.data.terms.remote.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TermsAgreementResponseDto(
+    @SerialName("isRequiredTermsAllAgreed")
+    val isRequiredTermsAllAgreed: Boolean
+)

--- a/app/src/main/java/com/kiero/data/terms/remote/dto/response/TermsItemResponseDto.kt
+++ b/app/src/main/java/com/kiero/data/terms/remote/dto/response/TermsItemResponseDto.kt
@@ -1,0 +1,14 @@
+package com.kiero.data.terms.remote.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TermsItemResponseDto(
+    @SerialName("termsId")
+    val termsId: Long,
+    @SerialName("termsType")
+    val termsType: String,
+    @SerialName("url")
+    val url: String,
+)

--- a/app/src/main/java/com/kiero/data/terms/repository/TermsRepository.kt
+++ b/app/src/main/java/com/kiero/data/terms/repository/TermsRepository.kt
@@ -1,0 +1,11 @@
+package com.kiero.data.terms.repository
+
+import com.kiero.data.terms.model.TermsAgreementModel
+import com.kiero.data.terms.model.TermsItemModel
+import com.kiero.data.terms.model.TermsStatusModel
+
+interface TermsRepository {
+    suspend fun getTermsStatus(): Result<TermsStatusModel>
+    suspend fun getTermsLink(): Result<List<TermsItemModel>>
+    suspend fun postTermsStatus(request: TermsAgreementModel) : Result<Unit>
+}

--- a/app/src/main/java/com/kiero/data/terms/repositoryimpl/TermsRepositoryImpl.kt
+++ b/app/src/main/java/com/kiero/data/terms/repositoryimpl/TermsRepositoryImpl.kt
@@ -1,0 +1,26 @@
+package com.kiero.data.terms.repositoryimpl
+
+import com.kiero.core.common.util.suspendRunCatching
+import com.kiero.data.terms.model.TermsAgreementModel
+import com.kiero.data.terms.model.TermsItemModel
+import com.kiero.data.terms.model.TermsStatusModel
+import com.kiero.data.terms.model.toModel
+import com.kiero.data.terms.remote.datasource.TermsDataSource
+import com.kiero.data.terms.repository.TermsRepository
+import javax.inject.Inject
+
+class TermsRepositoryImpl @Inject constructor(
+    private val termsDataSource: TermsDataSource
+) : TermsRepository {
+    override suspend fun getTermsStatus(): Result<TermsStatusModel> = suspendRunCatching {
+        termsDataSource.getTermsStatus().data!!.toModel()
+    }
+
+    override suspend fun getTermsLink(): Result<List<TermsItemModel>> = suspendRunCatching {
+        termsDataSource.getTermsLink().data!!.map { it.toModel() }
+    }
+
+    override suspend fun postTermsStatus(request: TermsAgreementModel): Result<Unit> = suspendRunCatching {
+        termsDataSource.postTermsStatus(request.toDto())
+    }
+}

--- a/app/src/main/java/com/kiero/domain/login/HandleKakaoLoginResultUseCase.kt
+++ b/app/src/main/java/com/kiero/domain/login/HandleKakaoLoginResultUseCase.kt
@@ -3,11 +3,13 @@ package com.kiero.domain.login
 import com.kiero.core.common.util.suspendRunCatching
 import com.kiero.core.localstorage.info.UserInfoManager
 import com.kiero.data.auth.repository.AuthRepository
-import com.kiero.presentation.auth.parent.model.KakaoLoginResult
+import com.kiero.data.terms.repository.TermsRepository
+import com.kiero.domain.login.model.KakaoLoginResult
 import javax.inject.Inject
 
 class HandleKakaoLoginResultUseCase @Inject constructor(
     private val authRepository: AuthRepository,
+    private val termsRepository: TermsRepository,
     private val userInfoManager: UserInfoManager
 ) {
     suspend operator fun invoke(
@@ -18,6 +20,13 @@ class HandleKakaoLoginResultUseCase @Inject constructor(
             parentName = name,
             parentProfileImage = image
         )
+
+        val termsStatus = termsRepository.getTermsStatus().getOrThrow()
+        userInfoManager.saveTermsInfo(isRequiredTermsAllAgreed = termsStatus.isRequiredTermsAllAgreed)
+
+        if (!termsStatus.isRequiredTermsAllAgreed) {
+            return@suspendRunCatching KakaoLoginResult.NeedTermsAgreement
+        }
 
         val children = authRepository.getChildren().getOrThrow()
 

--- a/app/src/main/java/com/kiero/domain/login/model/KakaoLoginResult.kt
+++ b/app/src/main/java/com/kiero/domain/login/model/KakaoLoginResult.kt
@@ -1,0 +1,7 @@
+package com.kiero.domain.login.model
+
+sealed interface KakaoLoginResult {
+    data object NeedTermsAgreement : KakaoLoginResult // 약관 동의 필요
+    data class HasChildren(val firstChildId: Int) : KakaoLoginResult // 자녀 있음
+    data object NoChildren : KakaoLoginResult // 자녀 없음 (온보딩 필요)
+}

--- a/app/src/main/java/com/kiero/domain/parent/mypage/WithDrawUseCase.kt
+++ b/app/src/main/java/com/kiero/domain/parent/mypage/WithDrawUseCase.kt
@@ -1,0 +1,18 @@
+package com.kiero.domain.parent.mypage
+
+import com.kiero.core.localstorage.TokenManager
+import com.kiero.data.parent.mypage.parent.repository.ParentMyPageRepository
+import javax.inject.Inject
+
+class WithDrawUseCase @Inject constructor(
+    private val parentMyPageRepository: ParentMyPageRepository,
+    private val tokenManager: TokenManager
+) {
+    suspend operator fun invoke(): Result<Unit> {
+        val result = parentMyPageRepository.postWithdrawStatus()
+
+        return result.onSuccess {
+            tokenManager.clearTokens()
+        }
+    }
+}

--- a/app/src/main/java/com/kiero/domain/parent/mypage/WithdrawUseCase.kt
+++ b/app/src/main/java/com/kiero/domain/parent/mypage/WithdrawUseCase.kt
@@ -4,7 +4,7 @@ import com.kiero.core.localstorage.TokenManager
 import com.kiero.data.parent.mypage.parent.repository.ParentMyPageRepository
 import javax.inject.Inject
 
-class WithDrawUseCase @Inject constructor(
+class WithdrawUseCase @Inject constructor(
     private val parentMyPageRepository: ParentMyPageRepository,
     private val tokenManager: TokenManager
 ) {

--- a/app/src/main/java/com/kiero/domain/parent/signup/PostTermsUseCase.kt
+++ b/app/src/main/java/com/kiero/domain/parent/signup/PostTermsUseCase.kt
@@ -1,0 +1,27 @@
+package com.kiero.domain.parent.signup
+
+import com.kiero.core.common.util.suspendRunCatching
+import com.kiero.core.localstorage.info.UserInfoManager
+import com.kiero.data.terms.model.TermsAgreementModel
+import com.kiero.data.terms.repository.TermsRepository
+import javax.inject.Inject
+
+class PostTermsUseCase @Inject constructor(
+    private val termsRepository: TermsRepository,
+    private val userInfoManager: UserInfoManager
+) {
+    suspend operator fun invoke() : Result<Unit> = suspendRunCatching{
+        val isTermsAgreed = userInfoManager.getTermsInfo() ?: false
+        if (!isTermsAgreed) {
+            return Result.failure(IllegalStateException("약관 동의가 필요합니다."))
+        }
+
+        val termsIds = userInfoManager.getAgreedTermsIds() ?: emptyList()
+
+        termsRepository.postTermsStatus(
+            request = TermsAgreementModel(
+                termsIds = termsIds
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/kiero/domain/parent/signup/PostTermsUseCase.kt
+++ b/app/src/main/java/com/kiero/domain/parent/signup/PostTermsUseCase.kt
@@ -13,7 +13,7 @@ class PostTermsUseCase @Inject constructor(
     suspend operator fun invoke() : Result<Unit> = suspendRunCatching{
         val isTermsAgreed = userInfoManager.getTermsInfo() ?: false
         if (!isTermsAgreed) {
-            return Result.failure(IllegalStateException("약관 동의가 필요합니다."))
+            throw IllegalStateException("약관 동의가 필요합니다.")
         }
 
         val termsIds = userInfoManager.getAgreedTermsIds() ?: emptyList()

--- a/app/src/main/java/com/kiero/domain/parent/splash/model/ParentAutoLoginResult.kt
+++ b/app/src/main/java/com/kiero/domain/parent/splash/model/ParentAutoLoginResult.kt
@@ -1,0 +1,8 @@
+package com.kiero.domain.parent.splash.model
+
+sealed interface ParentAutoLoginResult {
+    //data object MoveToTermsAgreement : ParentAutoLoginResult
+    data object MoveToParentHome : ParentAutoLoginResult
+    data object MoveToOnboarding : ParentAutoLoginResult // parentGraph로 이동
+    data object MoveToAuth : ParentAutoLoginResult
+}

--- a/app/src/main/java/com/kiero/domain/parent/splash/usecase/CheckParentAutoLoginUseCase.kt
+++ b/app/src/main/java/com/kiero/domain/parent/splash/usecase/CheckParentAutoLoginUseCase.kt
@@ -1,0 +1,40 @@
+package com.kiero.domain.parent.splash.usecase
+
+import com.kiero.core.localstorage.info.UserInfoManager
+import com.kiero.data.auth.repository.AuthRepository
+import com.kiero.domain.parent.splash.model.ParentAutoLoginResult
+import javax.inject.Inject
+
+class CheckParentAutoLoginUseCase @Inject constructor(
+    private val userInfoManager: UserInfoManager,
+    private val authRepository: AuthRepository
+) {
+    suspend operator fun invoke(): ParentAutoLoginResult {
+        // 권한 확인된게 없으면 로그인 화면(역할 선택 화면)으로
+        val isTermsAgreed = userInfoManager.getTermsInfo() ?: false
+        if (!isTermsAgreed) {
+            return ParentAutoLoginResult.MoveToAuth
+        }
+
+        val localChildId = userInfoManager.getChildIdInfo()
+        if (localChildId != null && localChildId > 0) { // 로컬에 ID가 있다면 바로 홈으로
+            return ParentAutoLoginResult.MoveToParentHome
+        }
+
+        val childrenResult = authRepository.getChildren()
+        return if (childrenResult.isSuccess) {
+            val children = childrenResult.getOrThrow()
+            if (children.isNotEmpty()) {
+                // 서버에서 확인한 자녀 정보를 로컬에 저장하고 홈으로
+                userInfoManager.saveChildIdInfo(children.first().childId)
+                ParentAutoLoginResult.MoveToParentHome
+            } else {
+                // 약관 동의는 했지만 자녀가 없는 경우 (자녀 등록/온보딩 화면으로)
+                ParentAutoLoginResult.MoveToOnboarding
+            }
+        } else {
+            // 통신 실패 등의 에러 상황 (로그인 화면으로 보내서 재시도 유도)
+            ParentAutoLoginResult.MoveToAuth
+        }
+    }
+}

--- a/app/src/main/java/com/kiero/presentation/auth/parent/AuthParentScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/auth/parent/AuthParentScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -48,6 +49,7 @@ fun AuthParentRoute(
 ) {
     val context = LocalContext.current
     val globalTrigger = LocalGlobalUiEventTrigger.current
+    val urlHandler = LocalUriHandler.current
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     viewModel.sideEffect.collectSingleEvent {
@@ -63,6 +65,8 @@ fun AuthParentRoute(
                     )
                 )
             }
+
+            is AuthSideEffect.OpenWebView -> urlHandler.openUri(it.url)
 
             AuthSideEffect.NavigateToParentGraph -> navigateToParentGraph()
             AuthSideEffect.NavigateToSelection -> navigateToSelection()
@@ -94,7 +98,8 @@ fun AuthParentRoute(
 
         if (state.isShowTermsAgreement) {
             TermsAgreementBottomSheet(
-                consentsItem = state.consents,
+                termsList = state.termsList,
+                isAllAgreed = state.isAllAgreed,
                 onDismiss = viewModel::showTermsAgreement,
                 onClickTerms = viewModel::toggleTermsAccepted,
                 navigateToTerms = viewModel::navigateToTerms,

--- a/app/src/main/java/com/kiero/presentation/auth/parent/component/KakaoLoginButton.kt
+++ b/app/src/main/java/com/kiero/presentation/auth/parent/component/KakaoLoginButton.kt
@@ -46,7 +46,7 @@ fun KakaoLoginButton(
         )
 
         Text(
-            text = "카카오톡 로그인",
+            text = "카카오 계정으로 로그인",
             style = KieroTheme.typography.semiBold.title3,
             color = KieroTheme.colors.black,
             textAlign = TextAlign.Center,

--- a/app/src/main/java/com/kiero/presentation/auth/parent/component/TermsAgreementBottomSheet.kt
+++ b/app/src/main/java/com/kiero/presentation/auth/parent/component/TermsAgreementBottomSheet.kt
@@ -26,17 +26,21 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kiero.R
+import com.kiero.core.common.extension.disableUpWardEvent
 import com.kiero.core.common.extension.noRippleClickable
 import com.kiero.core.designsystem.component.bottomsheet.KieroBottomSheet
 import com.kiero.core.designsystem.component.button.KieroButtonMedium
 import com.kiero.core.designsystem.theme.KieroTheme
-import com.kiero.presentation.auth.parent.model.AuthParentConsentsUiModel
 import com.kiero.presentation.auth.parent.model.TermsType
+import com.kiero.presentation.auth.parent.model.TermsUiModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TermsAgreementBottomSheet(
-    consentsItem: AuthParentConsentsUiModel,
+    termsList: ImmutableList<TermsUiModel>,
+    isAllAgreed: Boolean,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
     onClickTerms: (TermsType) -> Unit,
@@ -47,7 +51,8 @@ fun TermsAgreementBottomSheet(
         onDismiss = onDismiss,
     ) {
         TermsAgreementContent(
-            consentsItem = consentsItem,
+            termsList = termsList,
+            isAllAgreed = isAllAgreed,
             onConfirm = onConfirm,
             onClickTerms = onClickTerms,
             navigateToTerms = navigateToTerms,
@@ -58,7 +63,8 @@ fun TermsAgreementBottomSheet(
 
 @Composable
 private fun TermsAgreementContent(
-    consentsItem: AuthParentConsentsUiModel,
+    termsList: ImmutableList<TermsUiModel>,
+    isAllAgreed: Boolean,
     onConfirm: () -> Unit,
     onClickTerms: (TermsType) -> Unit,
     navigateToTerms: (TermsType) -> Unit,
@@ -67,6 +73,7 @@ private fun TermsAgreementContent(
     Column (
         modifier = modifier
             .fillMaxWidth()
+            .disableUpWardEvent()
             .dropShadow(
                 shape = RoundedCornerShape(topStart = 15.dp, topEnd = 15.dp),
                 shadow = Shadow(
@@ -95,35 +102,26 @@ private fun TermsAgreementContent(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        TermsItem(
-            termsText = "(필수) KIERO 이용약관 동의",
-            isSelected = consentsItem.isTermsAccepted,
-            onClickTerms = {
-                onClickTerms(TermsType.SERVICE_AGREEMENT)
-            },
-            navigateToTerms = {
-                navigateToTerms(TermsType.SERVICE_AGREEMENT)
-            },
-        )
+        termsList.forEachIndexed { index, term ->
+            TermsItem(
+                termsText = term.termsType.description,
+                isSelected = term.isAgreed,
+                onClickTerms = { onClickTerms(term.termsType) },
+                navigateToTerms = { navigateToTerms(term.termsType) },
+            )
 
-        Spacer(modifier = Modifier.height(24.dp))
-
-        TermsItem(
-            termsText = "(필수) 개인정보 필수 동의",
-            isSelected = consentsItem.isPrivacyPolicyAccepted,
-            onClickTerms = {
-                onClickTerms(TermsType.PRIVACY_POLICY)
-            },
-            navigateToTerms = {
-                navigateToTerms(TermsType.PRIVACY_POLICY)
-            },
-        )
+            if (index == termsList.lastIndex) {
+                Spacer(modifier = Modifier.height(20.dp))
+            } else {
+                Spacer(modifier = Modifier.height(24.dp))
+            }
+        }
 
         Spacer(modifier = Modifier.height(20.dp))
 
         KieroButtonMedium(
             text = "확인",
-            isEnabled = consentsItem.isTermsAccepted && consentsItem.isPrivacyPolicyAccepted,
+            isEnabled = isAllAgreed,
             onClick = onConfirm,
             modifier = Modifier
                 .padding(horizontal = 16.dp)
@@ -182,6 +180,21 @@ private fun TermsItem(
 @Composable
 private fun TermsAgreementBottomSheetPreview() {
     KieroTheme {
+        val dummyTermsList = persistentListOf(
+            TermsUiModel(
+                termsType = TermsType.SERVICE_AGREEMENT,
+                termsId = 1L,
+                url = "",
+                isAgreed = true
+            ),
+            TermsUiModel(
+                termsType = TermsType.PRIVACY_POLICY,
+                termsId = 2L,
+                url = "",
+                isAgreed = false
+            )
+        )
+
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -191,7 +204,8 @@ private fun TermsAgreementBottomSheetPreview() {
             )
 
             TermsAgreementContent(
-                consentsItem = AuthParentConsentsUiModel(),
+                termsList = dummyTermsList,
+                isAllAgreed = false,
                 onConfirm = {},
                 navigateToTerms = {},
                 onClickTerms = {},

--- a/app/src/main/java/com/kiero/presentation/auth/parent/model/AuthParentConsentsUiModel.kt
+++ b/app/src/main/java/com/kiero/presentation/auth/parent/model/AuthParentConsentsUiModel.kt
@@ -1,9 +1,0 @@
-package com.kiero.presentation.auth.parent.model
-
-import androidx.compose.runtime.Immutable
-
-@Immutable
-data class AuthParentConsentsUiModel(
-    val isTermsAccepted: Boolean = false,
-    val isPrivacyPolicyAccepted: Boolean = false
-)

--- a/app/src/main/java/com/kiero/presentation/auth/parent/model/KakaoLoginResult.kt
+++ b/app/src/main/java/com/kiero/presentation/auth/parent/model/KakaoLoginResult.kt
@@ -1,6 +1,0 @@
-package com.kiero.presentation.auth.parent.model
-
-sealed interface KakaoLoginResult {
-    data class HasChildren(val firstChildId: Int) : KakaoLoginResult
-    data object NoChildren : KakaoLoginResult
-}

--- a/app/src/main/java/com/kiero/presentation/auth/parent/model/TermsType.kt
+++ b/app/src/main/java/com/kiero/presentation/auth/parent/model/TermsType.kt
@@ -1,5 +1,19 @@
 package com.kiero.presentation.auth.parent.model
 
-enum class TermsType {
-    SERVICE_AGREEMENT, PRIVACY_POLICY
+enum class TermsType(
+    val description: String
+) {
+    SERVICE_AGREEMENT("(필수) KIERO 이용약관 동의"),
+    PRIVACY_POLICY("(필수) 개인정보 필수 동의"),
+    UNKNOWN("(필수) 알 수 없는 약관");
+
+    companion object {
+        fun fromServerString(value: String): TermsType {
+            return when (value) {
+                "SERVICE_TERMS" -> SERVICE_AGREEMENT
+                "PRIVACY_POLICY" -> PRIVACY_POLICY
+                else -> UNKNOWN
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/kiero/presentation/auth/parent/model/TermsUiModel.kt
+++ b/app/src/main/java/com/kiero/presentation/auth/parent/model/TermsUiModel.kt
@@ -1,0 +1,18 @@
+package com.kiero.presentation.auth.parent.model
+
+import androidx.compose.runtime.Immutable
+import com.kiero.data.terms.model.TermsItemModel
+
+@Immutable
+data class TermsUiModel(
+    val termsType: TermsType,
+    val termsId: Long,
+    val url: String,
+    val isAgreed: Boolean = false
+)
+
+fun TermsItemModel.toUiModel() = TermsUiModel(
+    termsType = TermsType.fromServerString(this.termsType),
+    termsId = termsId,
+    url = url,
+)

--- a/app/src/main/java/com/kiero/presentation/auth/parent/state/AuthParentContract.kt
+++ b/app/src/main/java/com/kiero/presentation/auth/parent/state/AuthParentContract.kt
@@ -2,11 +2,18 @@ package com.kiero.presentation.auth.parent.state
 
 import androidx.compose.runtime.Immutable
 import com.kiero.core.model.UiState
-import com.kiero.presentation.auth.parent.model.AuthParentConsentsUiModel
+import com.kiero.presentation.auth.parent.model.TermsType
+import com.kiero.presentation.auth.parent.model.TermsUiModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 @Immutable
 data class AuthParentState(
     val uiState: UiState<Unit> = UiState.Empty,
-    val consents: AuthParentConsentsUiModel = AuthParentConsentsUiModel(),
-    val isShowTermsAgreement: Boolean = false
-)
+    val isShowTermsAgreement: Boolean = false,
+    val termsList: ImmutableList<TermsUiModel> = persistentListOf()
+) {
+    private val validTerms = termsList.filter { it.termsType != TermsType.UNKNOWN }
+
+    val isAllAgreed: Boolean = validTerms.isNotEmpty() && validTerms.all { it.isAgreed }
+}

--- a/app/src/main/java/com/kiero/presentation/auth/parent/viewmodel/AuthParentViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/auth/parent/viewmodel/AuthParentViewModel.kt
@@ -6,14 +6,18 @@ import androidx.lifecycle.viewModelScope
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kiero.core.common.extension.toHandleErrorMessage
+import com.kiero.core.localstorage.info.UserInfoManager
 import com.kiero.core.model.UiState
 import com.kiero.data.auth.repository.AuthRepository
+import com.kiero.data.terms.repository.TermsRepository
 import com.kiero.domain.login.HandleKakaoLoginResultUseCase
-import com.kiero.presentation.auth.parent.model.KakaoLoginResult
+import com.kiero.domain.login.model.KakaoLoginResult
 import com.kiero.presentation.auth.parent.model.TermsType
+import com.kiero.presentation.auth.parent.model.toUiModel
 import com.kiero.presentation.auth.parent.state.AuthParentState
 import com.kiero.presentation.auth.state.AuthSideEffect
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -27,6 +31,8 @@ import javax.inject.Inject
 @HiltViewModel
 class AuthParentViewModel @Inject constructor(
     private val authRepository: AuthRepository,
+    private val termsRepository: TermsRepository,
+    private val userInfoManager: UserInfoManager,
     private val handleKakaoLoginResultUseCase: HandleKakaoLoginResultUseCase,
 ) : ViewModel() {
     private val _state = MutableStateFlow(AuthParentState())
@@ -43,13 +49,13 @@ class AuthParentViewModel @Inject constructor(
                 handleKakaoLoginResultUseCase(
                     name = result.name,
                     image = result.image
-                ).onSuccess { kakaoLoginResult ->
-                    when (kakaoLoginResult) {
-                        is KakaoLoginResult.HasChildren ->
-                            _sideEffect.emit(AuthSideEffect.NavigateToParentGraph)
-                        is KakaoLoginResult.NoChildren ->
-                            showTermsAgreement()
+                ).onSuccess { domainResult: KakaoLoginResult ->
+                    when (domainResult) {
+                        is KakaoLoginResult.NeedTermsAgreement -> showTermsAgreement()
+                        is KakaoLoginResult.HasChildren -> _sideEffect.emit(AuthSideEffect.NavigateToParentGraph)
+                        is KakaoLoginResult.NoChildren -> _sideEffect.emit(AuthSideEffect.NavigateToParentSignUp)
                     }
+
                 }.onFailure { throwable ->
                     Timber.e(throwable)
                     handleError(throwable)
@@ -76,26 +82,15 @@ class AuthParentViewModel @Inject constructor(
      * 이용약관 동의, 개인정보 상태를 토글합니다.
      */
     fun toggleTermsAccepted(termsType: TermsType) {
-        when (termsType) {
-            TermsType.SERVICE_AGREEMENT -> {
-                _state.update { currentState ->
-                    currentState.copy(
-                        consents = currentState.consents.copy(
-                            isTermsAccepted = !currentState.consents.isTermsAccepted
-                        )
-                    )
+        _state.update { currentState ->
+            val updatedList = currentState.termsList.map { term ->
+                if (term.termsType == termsType) {
+                    term.copy(isAgreed = !term.isAgreed)
+                } else {
+                    term
                 }
             }
-
-            TermsType.PRIVACY_POLICY -> {
-                _state.update { currentState ->
-                    currentState.copy(
-                        consents = currentState.consents.copy(
-                            isPrivacyPolicyAccepted = !currentState.consents.isPrivacyPolicyAccepted
-                        )
-                    )
-                }
-            }
+            currentState.copy(termsList = updatedList.toImmutableList())
         }
     }
 
@@ -105,57 +100,72 @@ class AuthParentViewModel @Inject constructor(
      */
     fun toggleAllConsents() {
         _state.update { currentState ->
-            val allAccepted = currentState.consents.isTermsAccepted && currentState.consents.isPrivacyPolicyAccepted
-
-            currentState.copy(
-                consents = currentState.consents.copy(
-                    isTermsAccepted = !allAccepted,
-                    isPrivacyPolicyAccepted = !allAccepted
-                )
-            )
+            val updatedList = currentState.termsList.map { term ->
+                term.copy(isAgreed = !currentState.isAllAgreed)
+            }
+            currentState.copy(termsList = updatedList.toImmutableList())
         }
     }
 
     fun showTermsAgreement() {
-        val isShowTermsAgreement = _state.value.isShowTermsAgreement
-
-        _state.update {
-            it.copy(
-                isShowTermsAgreement = !isShowTermsAgreement,
-                uiState = UiState.Empty
-            )
-        }
-    }
-
-    fun successTermsAgreement() {
         viewModelScope.launch {
+            val isShowTermsAgreement = _state.value.isShowTermsAgreement
+
+            if (!isShowTermsAgreement && _state.value.termsList.isEmpty()) {
+                termsRepository.getTermsLink()
+                    .onSuccess { terms ->
+                        _state.update { currentState ->
+                            currentState.copy(termsList = terms.map { it.toUiModel() }.toImmutableList())
+                        }
+                    }
+                    .onFailure {
+                        handleError(it)
+                        return@launch
+                    }
+            }
+
             _state.update {
                 it.copy(
-                    isShowTermsAgreement = false,
+                    isShowTermsAgreement = !isShowTermsAgreement,
                     uiState = UiState.Empty
                 )
             }
-
-            _sideEffect.emit(AuthSideEffect.NavigateToParentSignUp)
         }
     }
 
-    // Todo: 나중에 약관들 보여주는 화면으로 이동
+    /**
+     * 약관 동의 완료 처리 및 UserInfoManager에 저장
+     */
+    fun successTermsAgreement() {
+        viewModelScope.launch {
+            Timber.e("successTermsAgreement")
+            if (_state.value.isAllAgreed) {
+                val agreedTermsIds = _state.value.termsList.map { it.termsId }
+
+                userInfoManager.saveTermsInfo(isRequiredTermsAllAgreed = _state.value.isAllAgreed)
+                userInfoManager.saveAgreedTermsIds(agreedTermsIds)
+
+                _state.update { it.copy(isShowTermsAgreement = false) }
+                _sideEffect.emit(AuthSideEffect.NavigateToParentSignUp)
+            } else {
+                handleError(message = "필수 약관에 모두 동의해주세요.")
+            }
+        }
+    }
+
     fun navigateToTerms(termsType: TermsType) {
-        when (termsType) {
-            TermsType.SERVICE_AGREEMENT -> {
-                viewModelScope.launch {
-                    //_sideEffect.emit(AuthSideEffect.NavigateToTerms)
-                }
-            }
+        viewModelScope.launch {
+            val targetTerm = _state.value.termsList.find { it.termsType == termsType }
 
-            TermsType.PRIVACY_POLICY -> {
-                viewModelScope.launch {
-                    //_sideEffect.emit(AuthSideEffect.NavigateToPrivacyPolicy)
-                }
+            if (targetTerm != null && targetTerm.url.isNotBlank()) {
+                _sideEffect.emit(AuthSideEffect.OpenWebView(targetTerm.url))
+            } else {
+                handleError(message = "약관 링크를 찾을 수 없습니다.")
             }
         }
     }
+
+
 
     private suspend fun handleError(
         throwable: Throwable? = null,

--- a/app/src/main/java/com/kiero/presentation/auth/state/AuthContract.kt
+++ b/app/src/main/java/com/kiero/presentation/auth/state/AuthContract.kt
@@ -10,14 +10,11 @@ data class AuthState(
 
 sealed interface AuthSideEffect {
     data object NavigateUp : AuthSideEffect
-
     data object NavigateToParentSignUp : AuthSideEffect
-
-    data class ShowSnackbar(val message: String) : AuthSideEffect
-
     data object NavigateToParentGraph : AuthSideEffect
     data object NavigateToParent : AuthSideEffect
     data object NavigateToKid : AuthSideEffect
-
     data object NavigateToSelection : AuthSideEffect
+    data class ShowSnackbar(val message: String) : AuthSideEffect
+    data class OpenWebView(val url: String) : AuthSideEffect
 }

--- a/app/src/main/java/com/kiero/presentation/parent/component/ParentContentBottomSheet.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/component/ParentContentBottomSheet.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
@@ -26,7 +24,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kiero.R
-import com.kiero.core.common.extension.disableUpScroll
+import com.kiero.core.common.extension.disableUpWardEvent
 import com.kiero.core.common.extension.noRippleClickable
 import com.kiero.core.designsystem.theme.KieroTheme
 
@@ -53,9 +51,8 @@ fun ParentContentBottomSheet(
     ) {
         Column(
             modifier = Modifier
-                .disableUpScroll()
-                .verticalScroll(rememberScrollState())
                 .fillMaxWidth()
+                .disableUpWardEvent()
                 .background(color = KieroTheme.colors.gray900)
                 .padding(16.dp)
         ) {

--- a/app/src/main/java/com/kiero/presentation/parent/screen/journey/component/ParentJourneyBottomSheet.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/journey/component/ParentJourneyBottomSheet.kt
@@ -1,7 +1,5 @@
 package com.kiero.presentation.parent.screen.journey.component
 
-import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -11,8 +9,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -26,15 +22,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.kiero.R
 import com.kiero.core.common.extension.disableNestedScroll
-import com.kiero.core.common.extension.disableUpScroll
-import com.kiero.core.common.extension.disableUpSheetScroll
+import com.kiero.core.common.extension.disableUpWardEvent
 import com.kiero.core.common.extension.noRippleClickable
 import com.kiero.core.designsystem.component.bottomsheet.KieroBottomSheet
 import com.kiero.core.designsystem.component.chip.KieroChip
@@ -44,7 +38,6 @@ import com.kiero.core.designsystem.theme.KieroTheme
 import com.kiero.presentation.parent.screen.journey.model.JourneyMissionUiModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import timber.log.Timber
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -53,7 +46,6 @@ fun ParentJourneyBottomSheet(
     incompleteMissions: ImmutableList<JourneyMissionUiModel>,
     onDismiss: () -> Unit,
     sheetHeight: Dp,
-    modifier: Modifier = Modifier,
     initialTab: Int = 0, // 0 완료, 1 미완료
 ) {
     var selectedTabIndex by remember { mutableIntStateOf(initialTab) }
@@ -63,26 +55,12 @@ fun ParentJourneyBottomSheet(
     KieroBottomSheet(
         onDismiss = onDismiss,
         dragHandle = null,
-        modifier = modifier
-            .pointerInput(Unit) {
-                detectDragGestures { change, dragAmount ->
-                    Timber.e("dragAmount: $dragAmount")
-                }
-            },
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(sheetHeight)
-                .disableUpSheetScroll()
-                .pointerInput(Unit) {
-                    detectVerticalDragGestures { change, dragAmount ->
-                        // dragAmount가 0보다 작다 = 손가락을 위로 올리고 있다
-                        if (dragAmount < 0) {
-                            change.consume()
-                        }
-                    }
-                }
+                .disableUpWardEvent()
         ) {
             Row (
                 modifier = Modifier
@@ -141,16 +119,15 @@ fun ParentJourneyBottomSheet(
                         .weight(1f)
                         .fillMaxWidth()
                         .align(Alignment.CenterHorizontally)
-                        .disableUpScroll()
-                        .verticalScroll(rememberScrollState()),
+                        .disableUpWardEvent(),
                     bottomHeight = 50.dp
                 )
             } else {
                 LazyColumn(
                     modifier = Modifier
                         .weight(1f)
-                        .disableNestedScroll()
-                        .fillMaxWidth(),
+                        .fillMaxWidth()
+                        .disableNestedScroll(),
                 ) {
                     items(
                         items = currentList,

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mission/component/datepicker/component/CalendarBottomSheet.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mission/component/datepicker/component/CalendarBottomSheet.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -16,7 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kiero.R
-import com.kiero.core.common.extension.disableUpScroll
+import com.kiero.core.common.extension.disableUpWardEvent
 import com.kiero.core.designsystem.component.bottomsheet.KieroBottomSheet
 import com.kiero.core.designsystem.theme.KieroTheme
 import com.kiero.presentation.parent.screen.mission.component.datepicker.model.CalendarDisplayMode
@@ -44,10 +42,9 @@ fun CalendarBottomSheet(
     ) {
         Column(
             modifier = modifier
-                .disableUpScroll()
-                .verticalScroll(rememberScrollState())
                 .fillMaxWidth()
                 .fillMaxHeight(0.5f)
+                .disableUpWardEvent()
                 .padding(vertical = 20.dp, horizontal = 30.dp)
         ) {
             PickerTopbar(

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/ParentMyPageChildCareContract.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/ParentMyPageChildCareContract.kt
@@ -2,11 +2,13 @@ package com.kiero.presentation.parent.screen.mypage.childcare
 
 import com.kiero.presentation.parent.screen.mypage.childcare.model.ParentChildCareStep
 import com.kiero.presentation.parent.screen.mypage.childcare.model.ParentMyPageChildInfoModel
+import com.kiero.presentation.parent.screen.mypage.model.ChildConnectionStatus
 
 data class ParentMyPageChildCareState(
     val childInfo: ParentMyPageChildInfoModel = ParentMyPageChildInfoModel(),
     val expiredTime: String = "",
     val currentStep: ParentChildCareStep = ParentChildCareStep.MANAGEMENT,
+    val connectionStatus: ChildConnectionStatus = ChildConnectionStatus.CONNECTED,
     val isLogoutDialogVisible: Boolean = false,
     val isExpired: Boolean = false,
     val isLoading: Boolean = false,

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/ParentMyPageChildCareScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/ParentMyPageChildCareScreen.kt
@@ -91,7 +91,7 @@ fun ParentMyPageChildCareScreen(
         when(state.currentStep) {
             ParentChildCareStep.MANAGEMENT -> {
                 ParentMyPageChildManagementScreen(
-                    state = state.childInfo,
+                    state = state,
                     onReIssueClick = viewModel::onReIssueClick
                 )
             }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/ParentMyPageChildCareViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/ParentMyPageChildCareViewModel.kt
@@ -6,9 +6,11 @@ import androidx.lifecycle.viewModelScope
 import com.kiero.core.common.extension.toHandleErrorMessage
 import com.kiero.core.common.util.formatTime
 import com.kiero.core.localstorage.info.UserInfoManager
+import com.kiero.data.sse.manager.SseManager
 import com.kiero.domain.parent.invite.usecase.GetInviteCode
 import com.kiero.presentation.parent.screen.mypage.childcare.model.ParentChildCareStep
 import com.kiero.presentation.parent.screen.mypage.childcare.model.ParentMyPageChildInfoModel
+import com.kiero.presentation.parent.screen.mypage.model.ChildConnectionStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -19,12 +21,14 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class ParentMyPageChildCareViewModel @Inject constructor(
     private val getInviteCode: GetInviteCode,
     private val userInfoManager: UserInfoManager,
+    private val sseManager: SseManager,
 ) : ViewModel() {
     private val _state = MutableStateFlow(ParentMyPageChildCareState())
     val state = _state.asStateFlow()
@@ -36,10 +40,97 @@ class ParentMyPageChildCareViewModel @Inject constructor(
 
     private var lastCopyTime = 0L
 
+    init {
+        collectInviteEvents()
+        fetchChildInfo()
+    }
+
+    private fun collectInviteEvents() {
+        viewModelScope.launch {
+            sseManager.parentInviteEvents.collect { event ->
+                when (event.data.eventType) {
+                    "CHILD_JOINED" -> {
+                        Timber.d("자녀 가입 완료: ${event.data.childId}")
+                        handleChildJoined(event.data.childId)
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun handleChildJoined(childId: Long) {
+        userInfoManager.saveChildIdInfo(childId)
+        _state.update {
+            it.copy(
+                connectionStatus = ChildConnectionStatus.CONNECTED,
+                // 연결완료시 management로 이동할지 말지? Todo
+                // currentStep = ParentChildCareStep.MANAGEMENT
+            )
+        }
+        timerJob?.cancel()
+        _sideEffect.emit(ParentMyPageChildCareSideEffect.ShowSnackbar("자녀 연동이 완료되었습니다!"))
+    }
+
     fun fetchChildInfo() {
         viewModelScope.launch {
-            val childInfo = userInfoManager.getChildIdInfo()
+            val childLastName = userInfoManager.getChildLastName() ?: ""
+            val childFirstName = userInfoManager.getChildFirstName() ?: ""
+            val childId = userInfoManager.getChildIdInfo()
 
+            val pendingCode = userInfoManager.getPendingInviteCode()
+            val expireTime = userInfoManager.getPendingInviteExpireTime()
+            val currentTime = System.currentTimeMillis()
+
+            Timber.e("childId: $childId, pendingCode: $pendingCode, expireTime: $expireTime, currentTime: $currentTime")
+
+            // 현재 발급받은 유효한 코드가 남아있는가
+            if (!pendingCode.isNullOrEmpty() && expireTime > currentTime) {
+                _state.update {
+                    it.copy(
+                        childInfo = ParentMyPageChildInfoModel(
+                            code = pendingCode,
+                            childLastName = childLastName,
+                            childFirstName = childFirstName,
+                            isChildJoined = (childId != null)
+                        ),
+                        connectionStatus = ChildConnectionStatus.PENDING,
+                        currentStep = ParentChildCareStep.MANAGEMENT
+                    )
+                }
+                startTimer(expireTime)
+            }
+            // 진행 중인 코드는 없지만, 이미 연결된 자녀(childId)가 있는가?
+            else if (childId != null) {
+                if (expireTime <= currentTime) userInfoManager.clearPendingInviteCode()
+
+                _state.update {
+                    it.copy(
+                        childInfo = ParentMyPageChildInfoModel(
+                            childLastName = childLastName,
+                            childFirstName = childFirstName,
+                            isChildJoined = true
+                        ),
+                        connectionStatus = ChildConnectionStatus.CONNECTED,
+                        currentStep = ParentChildCareStep.MANAGEMENT
+                    )
+                }
+            }
+            // 연결된 자녀도 없고, 발급받은 코드도 없는 최초 상태
+            else {
+                if (expireTime <= currentTime) userInfoManager.clearPendingInviteCode()
+
+                _state.update {
+                    it.copy(
+                        childInfo = ParentMyPageChildInfoModel(
+                            childLastName = childLastName,
+                            childFirstName = childFirstName,
+                            isChildJoined = false
+                        ),
+                        connectionStatus = ChildConnectionStatus.CONNECTED,
+                        currentStep = ParentChildCareStep.MANAGEMENT
+                    )
+                }
+            }
         }
     }
 
@@ -59,18 +150,17 @@ class ParentMyPageChildCareViewModel @Inject constructor(
         }
     }
 
-    private fun startTimer() {
+    private fun startTimer(targetEndTimeMillis: Long) {
         timerJob?.cancel()
 
         timerJob = viewModelScope.launch {
-            val targetEndTime = SystemClock.elapsedRealtime() + TIMER_DURATION_MILLIS
-
             while (isActive) {
-                val currentTime = SystemClock.elapsedRealtime()
-                val remainingMillis = targetEndTime - currentTime
+                val currentTime = System.currentTimeMillis()
+                val remainingMillis = targetEndTimeMillis - currentTime
 
                 if (remainingMillis <= 0) {
                     // 타이머 종료 처리
+                    userInfoManager.clearPendingInviteCode()
                     _state.update {
                         it.copy(
                             expiredTime = formatTime(0),
@@ -115,6 +205,19 @@ class ParentMyPageChildCareViewModel @Inject constructor(
     }
 
     fun onReIssueClick() {
+        val currentState = _state.value
+
+        // 기존 code 유효 시 호출 스킵
+        if (currentState.currentStep == ParentChildCareStep.MANAGEMENT &&
+            currentState.connectionStatus == ChildConnectionStatus.PENDING &&
+            !currentState.isExpired &&
+            currentState.childInfo.code.isNotEmpty()
+        ) {
+            _state.update { it.copy(currentStep = ParentChildCareStep.INVITE) }
+            return
+        }
+
+        // 최초 발급 또는 유효시간이 끝난 재발급 시
         _state.update {
             it.copy(
                 isLoading = true,
@@ -127,34 +230,28 @@ class ParentMyPageChildCareViewModel @Inject constructor(
                 childLastName = _state.value.childInfo.childLastName,
                 childFirstName = _state.value.childInfo.childFirstName
             ).onSuccess { result ->
+                val targetEndTime = System.currentTimeMillis() + TIMER_DURATION_MILLIS
+                userInfoManager.savePendingInviteCode(result.code, targetEndTime)
+
                 _state.update {
                     it.copy(
-                        childInfo = ParentMyPageChildInfoModel(
+                        childInfo = it.childInfo.copy(
                             code = result.code,
                             childLastName = result.childLastName,
                             childFirstName = result.childFirstName
                         ),
-
+                        connectionStatus = ChildConnectionStatus.PENDING,
+                        currentStep = ParentChildCareStep.INVITE,
                         isLoading = false
                     )
                 }
 
-                if (_state.value.currentStep == ParentChildCareStep.MANAGEMENT) {
-                    _state.update {
-                        it.copy(
-                            currentStep = ParentChildCareStep.INVITE
-                        )
-                    }
-                }
+                // 계산해둔 절대 시간을 넘겨서 타이머 시작
+                startTimer(targetEndTime)
 
-                startTimer()
-            }.onFailure {
-                _sideEffect.emit(ParentMyPageChildCareSideEffect.ShowSnackbar(it.toHandleErrorMessage()))
-                _state.update { currentState ->
-                    currentState.copy(
-                        isLoading = false
-                    )
-                }
+            }.onFailure { error ->
+                _sideEffect.emit(ParentMyPageChildCareSideEffect.ShowSnackbar(error.toHandleErrorMessage()))
+                _state.update { it.copy(isLoading = false) }
             }
         }
     }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/component/ParentMyPageChildNameHolder.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/component/ParentMyPageChildNameHolder.kt
@@ -14,10 +14,12 @@ import androidx.compose.ui.unit.dp
 import com.kiero.core.designsystem.component.text.KieroTextHolder
 import com.kiero.core.designsystem.theme.KieroTheme
 import com.kiero.presentation.parent.screen.mypage.childcare.model.ParentMyPageChildInfoModel
+import com.kiero.presentation.parent.screen.mypage.model.ChildConnectionStatus
 
 @Composable
 fun ParentMyPageChildNameHolder(
     childInfo: ParentMyPageChildInfoModel,
+    connectionStatus: ChildConnectionStatus,
     modifier: Modifier = Modifier,
 ) {
     Column (
@@ -44,7 +46,7 @@ fun ParentMyPageChildNameHolder(
         Spacer(modifier = Modifier.height(6.dp))
 
         ParentMyPageChildStatus(
-            isChildJoined = childInfo.isChildJoined,
+            connectionStatus = connectionStatus,
             modifier = Modifier
                 .align(Alignment.End)
         )
@@ -60,7 +62,8 @@ private fun ParentMyPageChildNameHolderPreview() {
                 childLastName = "키",
                 childFirstName = "어로",
                 isChildJoined = true
-            )
+            ),
+            connectionStatus = ChildConnectionStatus.CONNECTED
         )
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/component/ParentMyPageChildStatus.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/component/ParentMyPageChildStatus.kt
@@ -14,13 +14,17 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kiero.R
 import com.kiero.core.designsystem.theme.KieroTheme
+import com.kiero.presentation.parent.screen.mypage.model.ChildConnectionStatus
 
-// Todo : 서버 SSE 또는 API 구현 시 status 변경
 @Composable
 fun ParentMyPageChildStatus(
+    connectionStatus: ChildConnectionStatus,
     modifier: Modifier = Modifier,
-    isChildJoined: Boolean = false,
 ) {
+    val isPending = connectionStatus == ChildConnectionStatus.PENDING
+    val statusText = if (isPending) "연결 대기" else "연결 완료"
+    val tintColor = if (isPending) KieroTheme.colors.main else KieroTheme.colors.gray300
+
     Row (
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
@@ -29,15 +33,15 @@ fun ParentMyPageChildStatus(
         Icon(
             imageVector = ImageVector.vectorResource(R.drawable.ic_info_circle),
             contentDescription = null,
-            tint = if (isChildJoined) KieroTheme.colors.gray300 else KieroTheme.colors.main,
+            tint = tintColor,
             modifier = Modifier
                 .size(11.dp)
         )
 
         Text(
-            text = if (isChildJoined) "연결 완료" else "연결 대기",
+            text = statusText,
             style = KieroTheme.typography.regular.body6,
-            color = if (isChildJoined) KieroTheme.colors.gray300 else KieroTheme.colors.main,
+            color = tintColor,
         )
     }
 }
@@ -46,6 +50,8 @@ fun ParentMyPageChildStatus(
 @Composable
 private fun ParentMyPageChildStatusPreview() {
     KieroTheme {
-        ParentMyPageChildStatus()
+        ParentMyPageChildStatus(
+            connectionStatus = ChildConnectionStatus.CONNECTED
+        )
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/model/ParentMyPageChildInfoModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/model/ParentMyPageChildInfoModel.kt
@@ -2,8 +2,8 @@ package com.kiero.presentation.parent.screen.mypage.childcare.model
 
 data class ParentMyPageChildInfoModel(
     val code: String = "",
-    val childLastName: String = "바",
-    val childFirstName: String = "바",
+    val childLastName: String = "",
+    val childFirstName: String = "",
     val isChildJoined: Boolean = false
 ) {
     val fullName: String = "$childLastName$childFirstName"

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/screen/ParentMyPageChildInviteScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/screen/ParentMyPageChildInviteScreen.kt
@@ -20,7 +20,8 @@ fun ParentMyPageChildInviteScreen(
 ) {
     Column {
         ParentMyPageChildNameHolder(
-            childInfo = state.childInfo
+            childInfo = state.childInfo,
+            connectionStatus = state.connectionStatus
         )
 
         Spacer(modifier = Modifier.height(11.dp))

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/screen/ParentMyPageChildManagementScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/screen/ParentMyPageChildManagementScreen.kt
@@ -1,5 +1,6 @@
 package com.kiero.presentation.parent.screen.mypage.childcare.screen
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -13,22 +14,25 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kiero.core.designsystem.component.button.KieroButtonMedium
 import com.kiero.core.designsystem.theme.KieroTheme
+import com.kiero.presentation.parent.screen.mypage.childcare.ParentMyPageChildCareState
 import com.kiero.presentation.parent.screen.mypage.childcare.component.ParentMyPageChildNameHolder
-import com.kiero.presentation.parent.screen.mypage.childcare.model.ParentMyPageChildInfoModel
+import com.kiero.presentation.parent.screen.mypage.model.ChildConnectionStatus
 
 @Composable
 fun ParentMyPageChildManagementScreen(
-    state: ParentMyPageChildInfoModel,
+    state: ParentMyPageChildCareState,
     onReIssueClick: () -> Unit,
 ) {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(KieroTheme.colors.black),
+            .background(KieroTheme.colors.black)
+            .animateContentSize(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         ParentMyPageChildNameHolder(
-            childInfo = state
+            childInfo = state.childInfo,
+            connectionStatus = state.connectionStatus
         )
 
         Spacer(modifier = Modifier.weight(1f))
@@ -41,8 +45,14 @@ fun ParentMyPageChildManagementScreen(
 
         Spacer(modifier = Modifier.height(24.dp))
 
+        val buttonText = if (state.connectionStatus == ChildConnectionStatus.PENDING && !state.isExpired) {
+            "연결 코드 확인"
+        } else {
+            "연결 코드 재발급"
+        }
+
         KieroButtonMedium(
-            text = "연결 코드 재발급",
+            text = buttonText,
             onClick = onReIssueClick,
             containerColor = KieroTheme.colors.main,
             contentColor = KieroTheme.colors.black
@@ -57,7 +67,7 @@ fun ParentMyPageChildManagementScreen(
 private fun ParentMyPageChildManagementScreenPreview() {
     KieroTheme {
         ParentMyPageChildManagementScreen(
-            state = ParentMyPageChildInfoModel(),
+            state = ParentMyPageChildCareState(),
             onReIssueClick = {}
         )
     }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/ParentMyPageContract.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/ParentMyPageContract.kt
@@ -18,5 +18,5 @@ sealed interface ParentMyPageSideEffect {
     data class ShowSnackBar(val message : String) : ParentMyPageSideEffect
 
     data object NavigateToChildCare: ParentMyPageSideEffect
-    data object NavigateToWithDraw : ParentMyPageSideEffect
+    data object NavigateToWithdraw : ParentMyPageSideEffect
 }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/ParentMyPageContract.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/ParentMyPageContract.kt
@@ -1,11 +1,15 @@
 package com.kiero.presentation.parent.screen.mypage.main
 
 import com.kiero.core.model.parent.ParentInfo
+import com.kiero.presentation.parent.screen.mypage.main.model.ParentMyPageMenuUiModel
 import com.kiero.presentation.parent.screen.mypage.model.ChildConnectionStatus
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 data class ParentMyPageState(
     val parentInfo : ParentInfo = ParentInfo(),
-    val connectionStatus: ChildConnectionStatus = ChildConnectionStatus.CONNECTED,
+    val myPageMenus : ImmutableList<ParentMyPageMenuUiModel> = persistentListOf(),
+    val connectionStatus: ChildConnectionStatus = ChildConnectionStatus.REISSUE,
     val isAlarmChecked: Boolean = false
 )
 

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/ParentMyPageScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/ParentMyPageScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -37,6 +38,8 @@ import com.kiero.core.trigger.LocalGlobalUiEventTrigger
 import com.kiero.presentation.parent.screen.mypage.main.component.AlarmSettingItem
 import com.kiero.presentation.parent.screen.mypage.main.component.ParentMyPageUserInfo
 import com.kiero.presentation.parent.screen.mypage.main.component.SettingItem
+import com.kiero.presentation.parent.screen.mypage.main.model.ParentMenuLinkType
+import com.kiero.presentation.parent.screen.mypage.main.model.actions.ParentMyPageActions
 
 @Composable
 fun ParentMyPageRoute(
@@ -47,11 +50,12 @@ fun ParentMyPageRoute(
     viewModel: ParentMyPageViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val uriHandler = LocalUriHandler.current
+    val globalTrigger = LocalGlobalUiEventTrigger.current
+
     var isLogOut by remember {
         mutableStateOf(false)
     }
-    
-    val globalTrigger = LocalGlobalUiEventTrigger.current
 
     viewModel.sideEffect.collectSideEffect {
         when (it) {
@@ -59,6 +63,7 @@ fun ParentMyPageRoute(
             is ParentMyPageSideEffect.ShowSnackBar -> globalTrigger.showSnackbar(
                 SnackbarState(
                     message = it.message,
+                    bottomPadding = 110
                 )
             )
 
@@ -67,26 +72,48 @@ fun ParentMyPageRoute(
         }
     }
 
+    val actions = remember(viewModel) {
+        object : ParentMyPageActions {
+            override fun onClickChildCare() = navigateToParentChildCare()
+
+            override fun onClickLogOut() {
+                isLogOut = true
+            }
+
+            override fun onClickLogOutConfirm() {
+                isLogOut = false
+                viewModel.logOut()
+            }
+
+            override fun onClickLogOutCancel() {
+                isLogOut = false
+            }
+
+            override fun onClickWithDraw() = navigateToWithDraw()
+
+            override fun onClickOss() = navigateToOssLicenses()
+
+            override fun onCheckedChange(checked: Boolean) {
+                viewModel.updateIsAlarmChecked(checked)
+            }
+
+            override fun onClickTerms(type: ParentMenuLinkType) {
+                val link = state.myPageMenus.find { it.linkType == type }?.link
+
+                if (!link.isNullOrEmpty()) {
+                    uriHandler.openUri(link)
+                } else {
+                    globalTrigger.showToast("링크를 찾을 수 없습니다.")
+                }
+            }
+        }
+    }
+
     ParentMyPageScreen(
         paddingValues = paddingValues,
         state = state,
         isLogOut = isLogOut,
-        onClickChildCare = navigateToParentChildCare, //viewModel::checkChildCare, Todo : 아이의 연결 여부 처리 확인하기
-        onClickLogOut = {
-            isLogOut = true
-        },
-        onClickLogOutConfirm = {
-            isLogOut = false
-            viewModel.logOut()
-        },
-        onClickLogOutCancel = {
-            isLogOut = false
-        },
-        onClickWithDraw = navigateToWithDraw,
-        onClickOss = navigateToOssLicenses,
-        onCheckedChange = {
-            viewModel.updateIsAlarmChecked(it)
-        }
+        actions = actions
     )
 }
 
@@ -95,13 +122,7 @@ private fun ParentMyPageScreen(
     paddingValues: PaddingValues,
     state: ParentMyPageState,
     isLogOut: Boolean,
-    onClickChildCare: () -> Unit = {},
-    onClickLogOut: () -> Unit = {},
-    onClickLogOutConfirm: () -> Unit = {},
-    onClickLogOutCancel: () -> Unit = {},
-    onClickWithDraw: () -> Unit = {},
-    onClickOss: () -> Unit = {},
-    onCheckedChange: (Boolean) -> Unit = {}
+    actions: ParentMyPageActions,
 ) {
     Box(
         modifier = Modifier
@@ -129,21 +150,23 @@ private fun ParentMyPageScreen(
             ) {
                 SettingItem(
                     text = "자녀 관리",
-                    onClick = onClickChildCare,
+                    onClick = actions::onClickChildCare,
                     connectionStatus = state.connectionStatus,
-                    hasConnectChildren = true,
+                    showConnectionStatus = true,
                 )
 
                 AlarmSettingItem(
                     text = "푸시 알림",
                     checked = state.isAlarmChecked,
                     enabled = true,
-                    onCheckedChange = onCheckedChange
+                    onCheckedChange = actions::onCheckedChange
                 )
 
                 SettingItem(
                     text = "고객 지원",
-                    onClick = {}
+                    onClick = {
+                        actions.onClickTerms(ParentMenuLinkType.CUSTOMER_SUPPORT)
+                    }
                 )
             }
 
@@ -166,17 +189,21 @@ private fun ParentMyPageScreen(
 
                 SettingItem(
                     text = "서비스 이용약관",
-                    onClick = {}, // Todo: 페이지 구현 시 반영
+                    onClick = {
+                        actions.onClickTerms(ParentMenuLinkType.SERVICE_TERMS)
+                    },
                 )
 
                 SettingItem(
                     text = "개인정보 처리방침",
-                    onClick = {} // Todo: 페이지 구현 시 반영
+                    onClick = {
+                        actions.onClickTerms(ParentMenuLinkType.PRIVACY_POLICY)
+                    }
                 )
 
                 SettingItem(
                     text = "오픈소스 라이선스",
-                    onClick = onClickOss
+                    onClick = actions::onClickOss
                 )
             }
 
@@ -203,7 +230,7 @@ private fun ParentMyPageScreen(
                     textDecoration = TextDecoration.Underline,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .noRippleClickable(onClick = onClickLogOut)
+                        .noRippleClickable(onClick = actions::onClickLogOut)
                 )
 
                 Text(
@@ -213,7 +240,7 @@ private fun ParentMyPageScreen(
                     textDecoration = TextDecoration.Underline,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .noRippleClickable(onClick = onClickWithDraw)
+                        .noRippleClickable(onClick = actions::onClickWithDraw)
                 )
 
                 Spacer(modifier = Modifier.height(70.dp))
@@ -223,12 +250,12 @@ private fun ParentMyPageScreen(
         if (isLogOut) {
             KieroDialog(
                 isDisabled = true,
-                onDismiss = onClickLogOutCancel,
+                onDismiss = actions::onClickLogOutCancel,
                 confirmAction = KieroConfirmAction(
-                    onClick = onClickLogOutConfirm
+                    onClick = actions::onClickLogOutConfirm
                 ),
                 cancelAction = KieroCancelAction(
-                    onClick = onClickLogOutCancel
+                    onClick = actions::onClickLogOutCancel
                 ),
                 title = "로그아웃",
                 subDescription = "로그아웃 하시겠습니까?"
@@ -246,7 +273,17 @@ private fun ParentMyPageScreenPreview() {
             state = ParentMyPageState(
                 parentInfo = ParentInfo(name = "키어로")
             ),
-            isLogOut = false
+            isLogOut = false,
+            actions = object : ParentMyPageActions {
+                override fun onClickChildCare() {}
+                override fun onClickLogOut() {}
+                override fun onClickLogOutConfirm() {}
+                override fun onClickLogOutCancel() {}
+                override fun onClickWithDraw() {}
+                override fun onClickOss() {}
+                override fun onCheckedChange(checked: Boolean) {}
+                override fun onClickTerms(type: ParentMenuLinkType) {}
+            }
         )
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/ParentMyPageScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/ParentMyPageScreen.kt
@@ -46,7 +46,7 @@ fun ParentMyPageRoute(
     paddingValues: PaddingValues,
     navigateToOssLicenses: () -> Unit,
     navigateToParentChildCare: () -> Unit,
-    navigateToWithDraw: () -> Unit,
+    navigateToWithdraw: () -> Unit,
     viewModel: ParentMyPageViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -68,7 +68,7 @@ fun ParentMyPageRoute(
             )
 
             is ParentMyPageSideEffect.NavigateToChildCare -> navigateToParentChildCare()
-            is ParentMyPageSideEffect.NavigateToWithDraw -> navigateToWithDraw()
+            is ParentMyPageSideEffect.NavigateToWithdraw -> navigateToWithdraw()
         }
     }
 
@@ -89,7 +89,7 @@ fun ParentMyPageRoute(
                 isLogOut = false
             }
 
-            override fun onClickWithDraw() = navigateToWithDraw()
+            override fun onClickWithdraw() = navigateToWithdraw()
 
             override fun onClickOss() = navigateToOssLicenses()
 
@@ -240,7 +240,7 @@ private fun ParentMyPageScreen(
                     textDecoration = TextDecoration.Underline,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .noRippleClickable(onClick = actions::onClickWithDraw)
+                        .noRippleClickable(onClick = actions::onClickWithdraw)
                 )
 
                 Spacer(modifier = Modifier.height(70.dp))
@@ -279,7 +279,7 @@ private fun ParentMyPageScreenPreview() {
                 override fun onClickLogOut() {}
                 override fun onClickLogOutConfirm() {}
                 override fun onClickLogOutCancel() {}
-                override fun onClickWithDraw() {}
+                override fun onClickWithdraw() {}
                 override fun onClickOss() {}
                 override fun onCheckedChange(checked: Boolean) {}
                 override fun onClickTerms(type: ParentMenuLinkType) {}

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/ParentMyPageViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/ParentMyPageViewModel.kt
@@ -6,8 +6,11 @@ import com.kiero.core.app.AppRestarter
 import com.kiero.core.localstorage.info.UserInfoManager
 import com.kiero.core.model.parent.ParentInfo
 import com.kiero.data.auth.repository.AuthRepository
+import com.kiero.data.parent.mypage.parent.repository.ParentMyPageRepository
+import com.kiero.presentation.parent.screen.mypage.main.model.toUiModel
 import com.kiero.presentation.parent.screen.mypage.model.ChildConnectionStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -20,6 +23,7 @@ import javax.inject.Inject
 @HiltViewModel
 class ParentMyPageViewModel @Inject constructor(
     private val authRepository: AuthRepository,
+    private val parentMyPageRepository: ParentMyPageRepository,
     private val userInfoManager: UserInfoManager,
     private val appRestarter: AppRestarter
 ) : ViewModel() {
@@ -31,20 +35,59 @@ class ParentMyPageViewModel @Inject constructor(
 
 
     init {
+        fetchMyPageTerms()
         fetchInfo()
     }
 
+    fun fetchMyPageTerms() {
+        viewModelScope.launch {
+            parentMyPageRepository.getParentTermsExternalLink()
+                .onSuccess { result ->
+                    _state.update { currentState ->
+                        currentState.copy(
+                            myPageMenus = result.map { it.toUiModel() }.toImmutableList()
+                        )
+                    }
+                }
+                .onFailure {
+                    Timber.e(it, "약관 불러오기 실패")
+                    _sideEffect.emit(ParentMyPageSideEffect.ShowToast("약관 불러오기에 실패했어요. 다시 시도해주세요."))
+                }
+        }
+    }
     fun fetchInfo() {
         viewModelScope.launch {
-            val kidInfo = userInfoManager.getChildIdInfo()
-            val userInfo = userInfoManager.getParentInfo()
+            parentMyPageRepository.getParentMyProfile()
+                .onSuccess { response ->
+                    _state.update {
+                        it.copy(
+                            parentInfo = ParentInfo(
+                                name = response.name,
+                                profileImage = response.image ?: ""
+                            ),
 
-            _state.update {
-                it.copy(
-                    parentInfo = userInfo ?: ParentInfo(),
-                    connectionStatus = if (kidInfo != null) ChildConnectionStatus.CONNECTED else ChildConnectionStatus.PENDING
-                )
-            }
+                            connectionStatus = if (response.hasPendingChildSession) {
+                                ChildConnectionStatus.PENDING
+                            } else {
+                                ChildConnectionStatus.REISSUE
+                            },
+
+                            isAlarmChecked = response.pushNotificationEnabled
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    Timber.e(error, "프로필 정보 불러오기 실패")
+                    val kidInfo = userInfoManager.getChildIdInfo()
+                    val userInfo = userInfoManager.getParentInfo()
+
+                    _state.update {
+                        it.copy(
+                            parentInfo = userInfo ?: ParentInfo(),
+                            connectionStatus = if (kidInfo != null) ChildConnectionStatus.REISSUE else ChildConnectionStatus.PENDING
+                        )
+                    }
+                }
         }
     }
 
@@ -66,14 +109,6 @@ class ParentMyPageViewModel @Inject constructor(
             it.copy(
                 isAlarmChecked = checked
             )
-        }
-    }
-
-    // 아이의 연결 유무를 판단하여 ui 업데이트 및 화면 이동
-    // Todo : 아이의 연결 여부 처리 확인하기
-    fun checkChildCare() {
-        viewModelScope.launch {
-            _sideEffect.emit(ParentMyPageSideEffect.NavigateToChildCare)
         }
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/component/SettingItem.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/component/SettingItem.kt
@@ -26,8 +26,8 @@ fun SettingItem(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    connectionStatus: ChildConnectionStatus = ChildConnectionStatus.CONNECTED,
-    hasConnectChildren: Boolean = false
+    connectionStatus: ChildConnectionStatus = ChildConnectionStatus.REISSUE,
+    showConnectionStatus: Boolean = false
 ) {
     Row(
         modifier = modifier
@@ -44,7 +44,7 @@ fun SettingItem(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        if (hasConnectChildren) {
+        if (showConnectionStatus) {
             val isPending = connectionStatus == ChildConnectionStatus.PENDING
 
             KieroChip(
@@ -52,7 +52,7 @@ fun SettingItem(
                 isEnabled = isPending,
                 isPoint = isPending,
                 action = KieroTextAction(
-                    text = if (isPending) "연결 대기" else "연결 코드 재발급",
+                    text = connectionStatus.text,
                     textColor = if (isPending) KieroTextColor.POINT else KieroTextColor.GRAY500,
                     onClick = {}
                 )
@@ -75,7 +75,7 @@ private fun SettingItemPreview() {
             text = "설정",
             onClick = {},
             connectionStatus = ChildConnectionStatus.PENDING,
-            hasConnectChildren = true
+            showConnectionStatus = true
         )
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/model/ParentMenuLinkType.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/model/ParentMenuLinkType.kt
@@ -1,0 +1,15 @@
+package com.kiero.presentation.parent.screen.mypage.main.model
+
+enum class ParentMenuLinkType {
+    PRIVACY_POLICY,
+    SERVICE_TERMS,
+    OPENSOURCE_LICENSE,
+    CUSTOMER_SUPPORT,
+    UNKNOWN;
+
+    companion object {
+        fun from(value: String): ParentMenuLinkType {
+            return entries.find { it.name == value } ?: UNKNOWN
+        }
+    }
+}

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/model/ParentMyPageMenuUiModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/model/ParentMyPageMenuUiModel.kt
@@ -1,0 +1,13 @@
+package com.kiero.presentation.parent.screen.mypage.main.model
+
+import com.kiero.data.parent.mypage.parent.model.ParentTermsModel
+
+data class ParentMyPageMenuUiModel(
+    val linkType: ParentMenuLinkType,
+    val link: String
+)
+
+fun ParentTermsModel.toUiModel() = ParentMyPageMenuUiModel(
+    linkType = ParentMenuLinkType.from(this.linkType),
+    link = this.link
+)

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/model/actions/ParentMyPageActions.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/model/actions/ParentMyPageActions.kt
@@ -1,0 +1,16 @@
+package com.kiero.presentation.parent.screen.mypage.main.model.actions
+
+import androidx.compose.runtime.Stable
+import com.kiero.presentation.parent.screen.mypage.main.model.ParentMenuLinkType
+
+@Stable
+interface ParentMyPageActions {
+    fun onClickChildCare()
+    fun onClickLogOut()
+    fun onClickLogOutConfirm()
+    fun onClickLogOutCancel()
+    fun onClickWithDraw()
+    fun onClickOss()
+    fun onCheckedChange(checked: Boolean)
+    fun onClickTerms(type: ParentMenuLinkType)
+}

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/model/actions/ParentMyPageActions.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/model/actions/ParentMyPageActions.kt
@@ -9,7 +9,7 @@ interface ParentMyPageActions {
     fun onClickLogOut()
     fun onClickLogOutConfirm()
     fun onClickLogOutCancel()
-    fun onClickWithDraw()
+    fun onClickWithdraw()
     fun onClickOss()
     fun onCheckedChange(checked: Boolean)
     fun onClickTerms(type: ParentMenuLinkType)

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/navigation/ParentMypageNavigation.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/navigation/ParentMypageNavigation.kt
@@ -15,7 +15,7 @@ import com.kiero.presentation.parent.screen.mypage.main.ParentMyPageRoute
 import com.kiero.presentation.parent.screen.mypage.main.route.licenses.OssLicensesScreen
 import com.kiero.presentation.parent.screen.mypage.main.route.licenses.navigation.OssLicenses
 import com.kiero.presentation.parent.screen.mypage.main.route.licenses.navigation.navigateToOssLicenses
-import com.kiero.presentation.parent.screen.mypage.withdraw.ParentMyPageWithDrawScreen
+import com.kiero.presentation.parent.screen.mypage.withdraw.ParentMyPageWithDrawRoute
 import com.kiero.presentation.parent.screen.mypage.withdraw.navigation.MyPageWithDraw
 import com.kiero.presentation.parent.screen.mypage.withdraw.navigation.navigateToMyPageWithDraw
 import kotlinx.serialization.Serializable
@@ -61,8 +61,8 @@ fun NavGraphBuilder.parentMypageNavGraph(
         }
 
         composable<MyPageWithDraw> {
-            ParentMyPageWithDrawScreen(
-                onBackClick = navigateUp
+            ParentMyPageWithDrawRoute(
+                navigateUp = navigateUp
             )
         }
     }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/navigation/ParentMypageNavigation.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/navigation/ParentMypageNavigation.kt
@@ -15,9 +15,9 @@ import com.kiero.presentation.parent.screen.mypage.main.ParentMyPageRoute
 import com.kiero.presentation.parent.screen.mypage.main.route.licenses.OssLicensesScreen
 import com.kiero.presentation.parent.screen.mypage.main.route.licenses.navigation.OssLicenses
 import com.kiero.presentation.parent.screen.mypage.main.route.licenses.navigation.navigateToOssLicenses
-import com.kiero.presentation.parent.screen.mypage.withdraw.ParentMyPageWithDrawRoute
-import com.kiero.presentation.parent.screen.mypage.withdraw.navigation.MyPageWithDraw
-import com.kiero.presentation.parent.screen.mypage.withdraw.navigation.navigateToMyPageWithDraw
+import com.kiero.presentation.parent.screen.mypage.withdraw.ParentMyPageWithdrawRoute
+import com.kiero.presentation.parent.screen.mypage.withdraw.navigation.MyPageWithdraw
+import com.kiero.presentation.parent.screen.mypage.withdraw.navigation.navigateToMyPageWithdraw
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -42,7 +42,7 @@ fun NavGraphBuilder.parentMypageNavGraph(
                 paddingValues = paddingValues,
                 navigateToOssLicenses = navController::navigateToOssLicenses,
                 navigateToParentChildCare = navController::navigateToMyPageChildCare,
-                navigateToWithDraw = navController::navigateToMyPageWithDraw
+                navigateToWithdraw = navController::navigateToMyPageWithdraw
             )
         }
 
@@ -60,8 +60,8 @@ fun NavGraphBuilder.parentMypageNavGraph(
             )
         }
 
-        composable<MyPageWithDraw> {
-            ParentMyPageWithDrawRoute(
+        composable<MyPageWithdraw> {
+            ParentMyPageWithdrawRoute(
                 navigateUp = navigateUp
             )
         }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/model/ChildConnectionStatus.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/model/ChildConnectionStatus.kt
@@ -1,6 +1,7 @@
 package com.kiero.presentation.parent.screen.mypage.model
 
-enum class ChildConnectionStatus {
-    CONNECTED,   // 연결 완료 (기본)
-    PENDING      // 연결 대기 (재발급 후 ~ 아이 인증 전)
+enum class ChildConnectionStatus(val text: String) {
+    PENDING("연결 대기"),          // hasPendingChildSession == true
+    REISSUE("연결 코드 재발급"),       // hasPendingChildSession == false (아이 연결 완료 또는 초기 상태)
+    CONNECTED("연결 완료") // 재발급 후 아이 연결완료 시
 }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/withdraw/ParentMyPageWithDrawScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/withdraw/ParentMyPageWithDrawScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.kiero.R
 import com.kiero.core.common.extension.noRippleClickable
 import com.kiero.core.designsystem.component.KieroTopbar
@@ -33,8 +34,20 @@ import com.kiero.core.designsystem.theme.KieroTheme
 
 // Todo: API 구현 시 반영
 @Composable
-fun ParentMyPageWithDrawScreen(
+fun ParentMyPageWithDrawRoute(
+    navigateUp: () -> Unit,
+    viewModel: ParentMyPageWithDrawViewModel = hiltViewModel()
+) {
+    ParentMyPageWithDrawScreen(
+        onBackClick = navigateUp,
+        onWithDraw = viewModel::withDraw
+    )
+}
+
+@Composable
+private fun ParentMyPageWithDrawScreen(
     onBackClick: () -> Unit,
+    onWithDraw: () -> Unit = {}
 ) {
     var isConfirmProcess by remember { mutableStateOf(false) }
 
@@ -108,10 +121,7 @@ fun ParentMyPageWithDrawScreen(
             text = "계정 삭제하고 탈퇴하기",
             isEnabled = isConfirmProcess,
             onClick = {
-                if (isConfirmProcess) {
-                    // TODO: 회원 탈퇴 API 호출
-                    onBackClick()
-                }
+                if (isConfirmProcess) onWithDraw()
             }
         )
     }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/withdraw/ParentMyPageWithDrawViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/withdraw/ParentMyPageWithDrawViewModel.kt
@@ -1,0 +1,28 @@
+package com.kiero.presentation.parent.screen.mypage.withdraw
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kiero.core.app.AppRestarter
+import com.kiero.domain.parent.mypage.WithDrawUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class ParentMyPageWithDrawViewModel @Inject constructor(
+    private val appRestarter: AppRestarter,
+    private val withDrawUseCase: WithDrawUseCase
+) : ViewModel() {
+    fun withDraw() {
+        viewModelScope.launch {
+            withDrawUseCase()
+                .onSuccess {
+                    appRestarter.restartApp()
+                }
+                .onFailure {
+                    Timber.e(it, "탈퇴 실패")
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/withdraw/ParentMyPageWithdrawScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/withdraw/ParentMyPageWithdrawScreen.kt
@@ -32,22 +32,21 @@ import com.kiero.core.designsystem.component.KieroTopbar
 import com.kiero.core.designsystem.component.button.KieroButtonMedium
 import com.kiero.core.designsystem.theme.KieroTheme
 
-// Todo: API 구현 시 반영
 @Composable
-fun ParentMyPageWithDrawRoute(
+fun ParentMyPageWithdrawRoute(
     navigateUp: () -> Unit,
-    viewModel: ParentMyPageWithDrawViewModel = hiltViewModel()
+    viewModel: ParentMyPageWithdrawViewModel = hiltViewModel()
 ) {
-    ParentMyPageWithDrawScreen(
+    ParentMyPageWithdrawScreen(
         onBackClick = navigateUp,
-        onWithDraw = viewModel::withDraw
+        onWithdraw = viewModel::withDraw
     )
 }
 
 @Composable
-private fun ParentMyPageWithDrawScreen(
+private fun ParentMyPageWithdrawScreen(
     onBackClick: () -> Unit,
-    onWithDraw: () -> Unit = {}
+    onWithdraw: () -> Unit = {}
 ) {
     var isConfirmProcess by remember { mutableStateOf(false) }
 
@@ -121,7 +120,7 @@ private fun ParentMyPageWithDrawScreen(
             text = "계정 삭제하고 탈퇴하기",
             isEnabled = isConfirmProcess,
             onClick = {
-                if (isConfirmProcess) onWithDraw()
+                if (isConfirmProcess) onWithdraw()
             }
         )
     }
@@ -129,9 +128,9 @@ private fun ParentMyPageWithDrawScreen(
 
 @Preview
 @Composable
-private fun ParentMyPageWithDrawScreenPreview() {
+private fun ParentMyPageWithdrawScreenPreview() {
     KieroTheme {
-        ParentMyPageWithDrawScreen(
+        ParentMyPageWithdrawScreen(
             onBackClick = {}
         )
     }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/withdraw/ParentMyPageWithdrawScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/withdraw/ParentMyPageWithdrawScreen.kt
@@ -39,7 +39,7 @@ fun ParentMyPageWithdrawRoute(
 ) {
     ParentMyPageWithdrawScreen(
         onBackClick = navigateUp,
-        onWithdraw = viewModel::withDraw
+        onWithdraw = viewModel::withdraw
     )
 }
 

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/withdraw/ParentMyPageWithdrawViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/withdraw/ParentMyPageWithdrawViewModel.kt
@@ -12,11 +12,11 @@ import javax.inject.Inject
 @HiltViewModel
 class ParentMyPageWithdrawViewModel @Inject constructor(
     private val appRestarter: AppRestarter,
-    private val withDrawUseCase: WithdrawUseCase
+    private val withdrawUseCase: WithdrawUseCase
 ) : ViewModel() {
-    fun withDraw() {
+    fun withdraw() {
         viewModelScope.launch {
-            withDrawUseCase()
+            withdrawUseCase()
                 .onSuccess {
                     appRestarter.restartApp()
                 }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/withdraw/ParentMyPageWithdrawViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/withdraw/ParentMyPageWithdrawViewModel.kt
@@ -3,16 +3,16 @@ package com.kiero.presentation.parent.screen.mypage.withdraw
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kiero.core.app.AppRestarter
-import com.kiero.domain.parent.mypage.WithDrawUseCase
+import com.kiero.domain.parent.mypage.WithdrawUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
-class ParentMyPageWithDrawViewModel @Inject constructor(
+class ParentMyPageWithdrawViewModel @Inject constructor(
     private val appRestarter: AppRestarter,
-    private val withDrawUseCase: WithDrawUseCase
+    private val withDrawUseCase: WithdrawUseCase
 ) : ViewModel() {
     fun withDraw() {
         viewModelScope.launch {

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/withdraw/navigation/ParentMyPageWithdrawNavigation.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/withdraw/navigation/ParentMyPageWithdrawNavigation.kt
@@ -5,11 +5,11 @@ import androidx.navigation.NavOptions
 import com.kiero.core.navigation.Route
 import kotlinx.serialization.Serializable
 
-fun NavController.navigateToMyPageWithDraw(
+fun NavController.navigateToMyPageWithdraw(
     navOptions: NavOptions? = null,
 ) {
-    navigate(MyPageWithDraw, navOptions)
+    navigate(MyPageWithdraw, navOptions)
 }
 
 @Serializable
-data object MyPageWithDraw: Route
+data object MyPageWithdraw: Route

--- a/app/src/main/java/com/kiero/presentation/parent/screen/schedule/plan/component/picker/ColorPicker.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/schedule/plan/component/picker/ColorPicker.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kiero.R
+import com.kiero.core.common.extension.disableUpWardEvent
 import com.kiero.core.common.extension.noRippleClickable
 import com.kiero.core.designsystem.theme.KieroTheme
 import com.kiero.presentation.parent.screen.schedule.plan.model.ColorType
@@ -55,14 +56,12 @@ fun ColorPickerBottomSheet(
         containerColor = KieroTheme.colors.gray900,
         dragHandle = null,
         modifier = modifier
-            .pointerInput(Unit) {
-                detectTapGestures { }
-            }
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(vertical = 16.dp)
+                .disableUpWardEvent()
         ) {
             PickerTopbar(
                 title = "컬러",

--- a/app/src/main/java/com/kiero/presentation/parent/screen/schedule/plan/component/picker/TimePicker.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/schedule/plan/component/picker/TimePicker.kt
@@ -3,7 +3,6 @@ package com.kiero.presentation.parent.screen.schedule.plan.component.picker
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,12 +13,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -39,8 +35,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kiero.R
 import com.kiero.core.common.extension.disableNestedScroll
-import com.kiero.core.common.extension.disableUpScroll
-import com.kiero.core.common.extension.disableUpSheetScroll
+import com.kiero.core.common.extension.disableUpWardEvent
 import com.kiero.core.common.extension.noRippleClickable
 import com.kiero.core.designsystem.theme.KieroTheme
 import com.sonms.wheelpicker.VerticalWheelPicker

--- a/app/src/main/java/com/kiero/presentation/signup/parent/ParentSignUpScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/signup/parent/ParentSignUpScreen.kt
@@ -84,7 +84,8 @@ fun ParentSignUpRoute(
             is ParentSignUpSideEffect.ShowSnackbar -> {
                 globalTrigger.showSnackbar(
                     SnackbarState(
-                        message = it.message
+                        message = it.message,
+                        bottomPadding = 110
                     )
                 )
             }

--- a/app/src/main/java/com/kiero/presentation/signup/parent/screen/ParentSignUpInviteScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/signup/parent/screen/ParentSignUpInviteScreen.kt
@@ -39,7 +39,6 @@ fun ParentSignUpInviteScreen(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        // Todo : 나중에 약관 동의 데이터도 함께 보낼 것
         KieroButtonMedium(
             text = "시작하기",
             onClick = onStartClick,

--- a/app/src/main/java/com/kiero/presentation/signup/parent/viewmodel/ParentSignUpViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/signup/parent/viewmodel/ParentSignUpViewModel.kt
@@ -11,6 +11,7 @@ import com.kiero.core.localstorage.info.UserInfoManager
 import com.kiero.data.auth.repository.AuthRepository
 import com.kiero.data.sse.manager.SseManager
 import com.kiero.domain.parent.invite.usecase.GetInviteCode
+import com.kiero.domain.parent.signup.PostTermsUseCase
 import com.kiero.presentation.signup.parent.model.ParentInfoUiModel
 import com.kiero.presentation.signup.parent.model.ParentSignUpStep
 import com.kiero.presentation.signup.parent.model.toUiModel
@@ -38,6 +39,7 @@ class ParentSignUpViewModel @Inject constructor(
     private val userInfoManager: UserInfoManager,
     private val tokenManager: TokenManager,
     private val sseManager: SseManager,
+    private val postTermsUseCase: PostTermsUseCase,
     private val getInviteCode: GetInviteCode,
 ) : ViewModel() {
     private val _state = MutableStateFlow(ParentSignUpState())
@@ -66,7 +68,24 @@ class ParentSignUpViewModel @Inject constructor(
 
             ParentSignUpStep.INVITE -> {
                 viewModelScope.launch {
-                    _sideEffect.emit(ParentSignUpSideEffect.NavigateToParent)
+                    _state.update { it.copy(isLoading = true) }
+
+                    postTermsUseCase()
+                        .onSuccess {
+                            userInfoManager.saveChildName(
+                                lastName = _state.value.childInfo.childLastName.text.toString(),
+                                firstName = _state.value.childInfo.childFirstName.text.toString()
+                            )
+
+                            _state.update { it.copy(isLoading = false) }
+                            _sideEffect.emit(ParentSignUpSideEffect.NavigateToParent)
+                        }
+                        .onFailure { error ->
+                            _state.update { it.copy(isLoading = false) }
+                            _sideEffect.emit(
+                                ParentSignUpSideEffect.ShowSnackbar(error.toHandleErrorMessage())
+                            )
+                        }
                 }
             }
         }

--- a/app/src/main/java/com/kiero/presentation/splash/state/SplashContract.kt
+++ b/app/src/main/java/com/kiero/presentation/splash/state/SplashContract.kt
@@ -2,8 +2,8 @@ package com.kiero.presentation.splash.state
 
 sealed interface SplashSideEffect {
     data object NavigateToAuth : SplashSideEffect
-    data object NavigateToParentHome : SplashSideEffect // 부모 스케쥴
-    data object NavigateToParentGraph : SplashSideEffect
+    data object NavigateToParentHome : SplashSideEffect // 부모 오늘의 현황
+    data object NavigateToParentGraph : SplashSideEffect // 카카오 로그인
     data object NavigateToKidHome : SplashSideEffect
     data object NavigateToKidOnboarding : SplashSideEffect
 }

--- a/app/src/main/java/com/kiero/presentation/splash/viewmodel/SplashViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/splash/viewmodel/SplashViewModel.kt
@@ -8,6 +8,8 @@ import com.kiero.core.localstorage.onboarding.OnboardingManager
 import com.kiero.core.model.auth.UserRole
 import com.kiero.core.network.auth.TokenRefreshService
 import com.kiero.data.auth.repository.AuthRepository
+import com.kiero.domain.parent.splash.model.ParentAutoLoginResult
+import com.kiero.domain.parent.splash.usecase.CheckParentAutoLoginUseCase
 import com.kiero.presentation.splash.state.SplashSideEffect
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
@@ -19,11 +21,10 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SplashViewModel @Inject constructor(
-    private val authRepository: AuthRepository,
     private val tokenManager: TokenManager,
     private val onboardingManager: OnboardingManager,
-    private val userInfoManager: UserInfoManager,
     private val reIssueManager: TokenRefreshService,
+    private val checkParentAutoLoginUseCase: CheckParentAutoLoginUseCase
 ) : ViewModel() {
     private val _sideEffect = Channel<SplashSideEffect>()
     val sideEffect = _sideEffect.receiveAsFlow()
@@ -56,24 +57,21 @@ class SplashViewModel @Inject constructor(
     }
 
     private suspend fun handleParentLogin() {
-        authRepository.getChildren()
-            .onSuccess { children ->
-                Timber.e("children $children")
-                if (children.isEmpty()) {
-                    // 자녀가 없으면 카카오 로그인으로
-                    _sideEffect.send(SplashSideEffect.NavigateToParentGraph)
-                } else {
-                    // 자녀가 있으면 첫 번째 자녀 정보 저장 후 스케줄로
-                    Timber.e("children.first().childId ${children.first().childId}")
-                    userInfoManager.saveChildIdInfo(children.first().childId)
+        val result = checkParentAutoLoginUseCase()
 
-                    _sideEffect.send(SplashSideEffect.NavigateToParentHome)
-                }
-            }
-            .onFailure { t ->
-                Timber.e(t, "자녀 목록 조회 실패")
-                _sideEffect.send(SplashSideEffect.NavigateToAuth)
-            }
+        when (result) {
+            /*is ParentAutoLoginResult.MoveToTermsAgreement ->
+                _sideEffect.send(SplashSideEffect.NavigateToAuth)*/
+
+            is ParentAutoLoginResult.MoveToParentHome ->
+                _sideEffect.send(SplashSideEffect.NavigateToParentHome) // 자녀가 있으면 첫 번째 자녀 정보 저장 후 스케줄로 NavigateToParentHome
+
+            is ParentAutoLoginResult.MoveToOnboarding ->
+                _sideEffect.send(SplashSideEffect.NavigateToParentGraph) // 부모 카카오 로그인 화면
+
+            is ParentAutoLoginResult.MoveToAuth ->
+                _sideEffect.send(SplashSideEffect.NavigateToAuth) // 역할 선택 화면
+        }
     }
 
     // 아이 로그인 처리 분리


### PR DESCRIPTION
## ISSUE
- closed #169 

## ❗ WORK DESCRIPTION
- 바텀시트 로직을 개선하였습니다
기존의 바텀시트 관련 확장 함수들이 파편화되어 있어서 스크롤이 있을 때 필요한 확장함수와 스크롤이 없을 때 필요한 확장함수 2개로 만들어 사용하기 쉽게 개편하였습니다

- 부모 마이페이지 API, Terms API, 아이 외부 링크 API를 구현했습니다
해당 과정에서 필요한 정보를 토대로 DataStore에 저장하는 함수도 같이 구현했습니다 이 과정에서 비대한 ViewModel을 방지하기 위해 UseCase를 최대한 활용하였습니다

- Terms API 가 추가되면서..
기존 로직에서 약관 관련 API가 추가되면서 분기가 너무 많아짐과 동시에 유지보수의 불편함이 생겨 Domain의 Model 에 interface를 통해 행위를 지정하는 방식 개선하여 단방향 데이터 흐름이 명확해져 좀 더 가독성과 효율, 유지보수성을 증가 시켰습니다

- ParentMyPageActions (State Holder)
마이페이지에서 너무 많은 클릭 이벤트와 이동 로직이 필요한 관계로 상태 호이스팅하는 람다 함수가 너무 많아져 가독성이 떨어지고 관리에 어려움을 느껴 State Holder 패턴을 적용하여 인터페이스로 리팩토링 하였습니다

   => 이점으로 보일러플레이트가 감소하고 응집도를 높였고 람다 객체 생성 비용을 줄였습니다 또한ParentMyPageActions 객체가 리컴포지션 전후로 완전히 동일함을 컴포즈가 인식하기 때문에 불필요한 리컴포지션을 방지했습니다

   => 추가적으로 Actions의 구현체를 MVI처럼 ViewModel을 거쳐 UDF를 만들기는 장점이 있지만 과도한 보일러플레이드 + UI 상태와의 결합이 이뤄져 ViewModel이 비대해지는 것을 방지 + 서버 통신, 핵심 비즈니스 로직만을 ViewModel에 위임하는 등 관심사의 분리와 코드의 간결성을 위해 해당 방식을 택했습니다

   => remember의 key로 viewmodel을 준 이유는 actions의 내부 코드는 viewmodel이라는 외부 변수를 내부에서 참조하고 있는 형태 이기 때문에 viewmodel 인스턴스가 교체되었을 때 기존 viewmodel을 참조하여 발생하는 오작동과 메모리 누수를 방지하기 위해 지정하였습니다

## 📢 TO REVIEWERS
- 고봉밥 들어갑니다잉~