### PR TITLE
[mod/#184] SP2 부모 마이페이지, 동의 여부 관련 QA-2

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-06-02T15:45:13.404830Z">
+        <DropdownSelection timestamp="2026-06-06T13:21:33.483617Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="PhysicalDevice" identifier="serial=R3CW60EWSYE" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/sonms/.android/avd/Pixel_10_Pro.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/src/main/java/com/kiero/data/sse/manager/SseManager.kt
+++ b/app/src/main/java/com/kiero/data/sse/manager/SseManager.kt
@@ -54,8 +54,14 @@ class SseManager @Inject constructor(
         replay = 0,
         extraBufferCapacity = 1
     )
-
     val parentScheduleEvents = _parentScheduleEvents.asSharedFlow()
+
+    private val _parentMissionCompleteEvents = MutableSharedFlow<SseEvent.Parent.MissionComplete>(
+        replay = 0,
+        extraBufferCapacity = 1
+    )
+    val parentMissionCompleteEvents = _parentMissionCompleteEvents.asSharedFlow()
+
 
 
 
@@ -289,6 +295,7 @@ class SseManager @Inject constructor(
             is SseEvent.Parent.Invite -> _parentInviteEvents.emit(event)
             is SseEvent.Parent.Feed -> _parentFeedEvents.emit(event)
             is SseEvent.Parent.Schedule -> _parentScheduleEvents.emit(event)
+            is SseEvent.Parent.MissionComplete -> _parentMissionCompleteEvents.emit(event)
             else -> Timber.w("부모 모드에서 알 수 없는 이벤트: $event")
         }
     }

--- a/app/src/main/java/com/kiero/data/sse/model/SseEvent.kt
+++ b/app/src/main/java/com/kiero/data/sse/model/SseEvent.kt
@@ -18,6 +18,7 @@ sealed class SseEvent {
         data class Invite(val data: InviteDataDto, override val eventId: String? = null) : Parent()
         data class Feed(val data: FeedDataDto, override val eventId: String? = null) : Parent()
         data class Schedule(val data: ParentScheduleDataDto, override val eventId: String? = null) : Parent()
+        data class MissionComplete(val data: MissionDataDto, override val eventId: String? = null) : Parent()
     }
 
     // 자녀 전용

--- a/app/src/main/java/com/kiero/data/sse/repositoryimpl/SseRepositoryImpl.kt
+++ b/app/src/main/java/com/kiero/data/sse/repositoryimpl/SseRepositoryImpl.kt
@@ -88,12 +88,17 @@ class SseRepositoryImpl @Inject constructor(
                 }
             }
 
-            // 아이
             SseEventType.MISSION -> {
                 try {
                     val data = json.decodeFromString<MissionDataDto>(raw.data)
-                    Timber.d("📋 Mission 이벤트 파싱 성공: ${data.missionName}")
-                    SseEvent.Kid.Mission(data, eventId = raw.id)
+                    val userRole = userInfoManager.getUserRole()
+                    if (userRole == UserRole.PARENT) {
+                        Timber.d("📋 Parent MissionComplete 이벤트 파싱 성공: ${data.missionName}")
+                        SseEvent.Parent.MissionComplete(data, eventId = raw.id)
+                    } else {
+                        Timber.d("📋 Child Mission 이벤트 파싱 성공: ${data.missionName}")
+                        SseEvent.Kid.Mission(data, eventId = raw.id)
+                    }
                 } catch (e: Exception) {
                     Timber.e(e, "Mission 파싱 실패: ${raw.data}")
                     null

--- a/app/src/main/java/com/kiero/domain/parent/signup/PostTermsUseCase.kt
+++ b/app/src/main/java/com/kiero/domain/parent/signup/PostTermsUseCase.kt
@@ -20,7 +20,7 @@ class PostTermsUseCase @Inject constructor(
             request = TermsAgreementModel(
                 termsIds = termsIds
             )
-        )
+        ).getOrThrow()
 
         userInfoManager.saveTermsInfo(isRequiredTermsAllAgreed = true)
     }

--- a/app/src/main/java/com/kiero/domain/parent/signup/PostTermsUseCase.kt
+++ b/app/src/main/java/com/kiero/domain/parent/signup/PostTermsUseCase.kt
@@ -11,17 +11,17 @@ class PostTermsUseCase @Inject constructor(
     private val userInfoManager: UserInfoManager
 ) {
     suspend operator fun invoke() : Result<Unit> = suspendRunCatching{
-        val isTermsAgreed = userInfoManager.getTermsInfo() ?: false
-        if (!isTermsAgreed) {
+        val termsIds = userInfoManager.getAgreedTermsIds() ?: emptyList()
+        if (termsIds.isEmpty()) {
             throw IllegalStateException("약관 동의가 필요합니다.")
         }
-
-        val termsIds = userInfoManager.getAgreedTermsIds() ?: emptyList()
 
         termsRepository.postTermsStatus(
             request = TermsAgreementModel(
                 termsIds = termsIds
             )
         )
+
+        userInfoManager.saveTermsInfo(isRequiredTermsAllAgreed = true)
     }
 }

--- a/app/src/main/java/com/kiero/domain/parent/splash/usecase/CheckParentAutoLoginUseCase.kt
+++ b/app/src/main/java/com/kiero/domain/parent/splash/usecase/CheckParentAutoLoginUseCase.kt
@@ -2,17 +2,25 @@ package com.kiero.domain.parent.splash.usecase
 
 import com.kiero.core.localstorage.info.UserInfoManager
 import com.kiero.data.auth.repository.AuthRepository
+import com.kiero.data.terms.repository.TermsRepository
 import com.kiero.domain.parent.splash.model.ParentAutoLoginResult
 import javax.inject.Inject
 
 class CheckParentAutoLoginUseCase @Inject constructor(
     private val userInfoManager: UserInfoManager,
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val termsRepository: TermsRepository
 ) {
     suspend operator fun invoke(): ParentAutoLoginResult {
-        // 권한 확인된게 없으면 로그인 화면(역할 선택 화면)으로
-        val isTermsAgreed = userInfoManager.getTermsInfo() ?: false
-        if (!isTermsAgreed) {
+        val termsStatus = termsRepository.getTermsStatus()
+            .getOrElse {
+                userInfoManager.saveTermsInfo(isRequiredTermsAllAgreed = false)
+                return ParentAutoLoginResult.MoveToAuth
+            }
+
+        userInfoManager.saveTermsInfo(termsStatus.isRequiredTermsAllAgreed)
+
+        if (!termsStatus.isRequiredTermsAllAgreed) {
             return ParentAutoLoginResult.MoveToAuth
         }
 

--- a/app/src/main/java/com/kiero/presentation/auth/parent/component/TermsAgreementBottomSheet.kt
+++ b/app/src/main/java/com/kiero/presentation/auth/parent/component/TermsAgreementBottomSheet.kt
@@ -24,9 +24,9 @@ import androidx.compose.ui.graphics.shadow.Shadow
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.kiero.R
-import com.kiero.core.common.extension.disableUpWardEvent
 import com.kiero.core.common.extension.noRippleClickable
 import com.kiero.core.designsystem.component.bottomsheet.KieroBottomSheet
 import com.kiero.core.designsystem.component.button.KieroButtonMedium
@@ -73,12 +73,12 @@ private fun TermsAgreementContent(
     Column (
         modifier = modifier
             .fillMaxWidth()
-            .disableUpWardEvent()
             .dropShadow(
                 shape = RoundedCornerShape(topStart = 15.dp, topEnd = 15.dp),
                 shadow = Shadow(
                     radius = 8.dp,
                     color = KieroTheme.colors.gray900,
+                    offset = DpOffset(x = 0.dp, y = ((-3).dp))
                 )
             )
             .background(

--- a/app/src/main/java/com/kiero/presentation/auth/parent/viewmodel/AuthParentViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/auth/parent/viewmodel/AuthParentViewModel.kt
@@ -142,7 +142,6 @@ class AuthParentViewModel @Inject constructor(
             if (_state.value.isAllAgreed) {
                 val agreedTermsIds = _state.value.termsList.map { it.termsId }
 
-                userInfoManager.saveTermsInfo(isRequiredTermsAllAgreed = _state.value.isAllAgreed)
                 userInfoManager.saveAgreedTermsIds(agreedTermsIds)
 
                 _state.update { it.copy(isShowTermsAgreement = false) }

--- a/app/src/main/java/com/kiero/presentation/auth/parent/viewmodel/AuthParentViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/auth/parent/viewmodel/AuthParentViewModel.kt
@@ -12,6 +12,7 @@ import com.kiero.data.auth.repository.AuthRepository
 import com.kiero.data.terms.repository.TermsRepository
 import com.kiero.domain.login.HandleKakaoLoginResultUseCase
 import com.kiero.domain.login.model.KakaoLoginResult
+import com.kiero.domain.parent.signup.PostTermsUseCase
 import com.kiero.presentation.auth.parent.model.TermsType
 import com.kiero.presentation.auth.parent.model.toUiModel
 import com.kiero.presentation.auth.parent.state.AuthParentState
@@ -34,6 +35,7 @@ class AuthParentViewModel @Inject constructor(
     private val termsRepository: TermsRepository,
     private val userInfoManager: UserInfoManager,
     private val handleKakaoLoginResultUseCase: HandleKakaoLoginResultUseCase,
+    private val postTermsUseCase: PostTermsUseCase,
 ) : ViewModel() {
     private val _state = MutableStateFlow(AuthParentState())
     val state: StateFlow<AuthParentState> = _state.asStateFlow()
@@ -144,8 +146,28 @@ class AuthParentViewModel @Inject constructor(
 
                 userInfoManager.saveAgreedTermsIds(agreedTermsIds)
 
-                _state.update { it.copy(isShowTermsAgreement = false) }
-                _sideEffect.emit(AuthSideEffect.NavigateToParentSignUp)
+                val hasConnectedChild = userInfoManager.getChildIdInfo() != null
+                if (!hasConnectedChild) {
+                    _state.update { it.copy(isShowTermsAgreement = false) }
+                    _sideEffect.emit(AuthSideEffect.NavigateToParentSignUp)
+                    return@launch
+                }
+
+                _state.update {
+                    it.copy(
+                        isShowTermsAgreement = false,
+                        uiState = UiState.Loading
+                    )
+                }
+
+                postTermsUseCase()
+                    .onSuccess {
+                        navigateAfterTermsAgreement()
+                    }
+                    .onFailure { throwable ->
+                        Timber.e(throwable)
+                        handleError(throwable)
+                    }
             } else {
                 handleError(message = "필수 약관에 모두 동의해주세요.")
             }
@@ -162,6 +184,30 @@ class AuthParentViewModel @Inject constructor(
                 handleError(message = "약관 링크를 찾을 수 없습니다.")
             }
         }
+    }
+
+
+    private suspend fun navigateAfterTermsAgreement() {
+        authRepository.getChildren()
+            .onSuccess { children ->
+                val firstChild = children.firstOrNull()
+
+                if (firstChild != null) {
+                    userInfoManager.saveChildIdInfo(childId = firstChild.childId)
+                    userInfoManager.saveChildName(
+                        lastName = firstChild.childLastName,
+                        firstName = firstChild.childFirstName
+                    )
+                }
+
+                _state.update { it.copy(uiState = UiState.Empty) }
+                _sideEffect.emit(AuthSideEffect.NavigateToParentGraph)
+            }
+            .onFailure { throwable ->
+                Timber.e(throwable)
+                _state.update { it.copy(uiState = UiState.Empty) }
+                _sideEffect.emit(AuthSideEffect.NavigateToParentGraph)
+            }
     }
 
 

--- a/app/src/main/java/com/kiero/presentation/main/navigation/KieroNavHost.kt
+++ b/app/src/main/java/com/kiero/presentation/main/navigation/KieroNavHost.kt
@@ -1,8 +1,7 @@
 package com.kiero.presentation.main.navigation
 
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -39,28 +38,16 @@ fun KieroNavHost(
         navController = appState.navController,
         startDestination = startDestination,
         enterTransition = {
-            slideInHorizontally(
-                initialOffsetX = { fullWidth -> fullWidth },
-                animationSpec = tween(durationMillis = 300)
-            )
+            EnterTransition.None
         },
         exitTransition = {
-            slideOutHorizontally(
-                targetOffsetX = { fullWidth -> -fullWidth },
-                animationSpec = tween(durationMillis = 300)
-            )
+            ExitTransition.None
         },
         popEnterTransition = {
-            slideInHorizontally(
-                initialOffsetX = { fullWidth -> -fullWidth },
-                animationSpec = tween(durationMillis = 300)
-            )
+            EnterTransition.None
         },
         popExitTransition = {
-            slideOutHorizontally(
-                targetOffsetX = { fullWidth -> fullWidth },
-                animationSpec = tween(durationMillis = 300)
-            )
+            ExitTransition.None
         },
         modifier = modifier
     ) {

--- a/app/src/main/java/com/kiero/presentation/parent/screen/journey/ParentJourneyScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/journey/ParentJourneyScreen.kt
@@ -61,6 +61,7 @@ fun ParentJourneyRoute(
     val context = LocalContext.current
     var showInitialPermissionDialog by remember { mutableStateOf(false) }
     var triggerPermissionRequest by remember { mutableStateOf(false) }
+    var hasSkippedInitialResume by remember { mutableStateOf(false) }
 
     val deniedCount by viewModel.notificationDeniedCount.collectAsStateWithLifecycle()
 
@@ -103,17 +104,15 @@ fun ParentJourneyRoute(
         }
     }
 
-    LaunchedEffect(state.kidInfo.kidId) {
-        if (state.kidInfo.kidId.isNotEmpty()) {
-            viewModel.fetchParentJourney(state.kidInfo.kidId.toLong())
-        }
-    }
-
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        if (!hasSkippedInitialResume) {
+            hasSkippedInitialResume = true
+            return@LifecycleEventEffect
+        }
+
         if (state.kidInfo.kidId.isNotEmpty()) {
             viewModel.fetchParentJourney(state.kidInfo.kidId.toLong())
         }
-
     }
 
     ParentJourneyScreen(

--- a/app/src/main/java/com/kiero/presentation/parent/screen/journey/ParentJourneyViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/journey/ParentJourneyViewModel.kt
@@ -1,7 +1,9 @@
 package com.kiero.presentation.parent.screen.journey
 
+import android.os.SystemClock
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.kiero.core.localstorage.info.UserInfoManager
 import com.kiero.core.localstorage.permission.PermissionInfoManager
 import com.kiero.core.permission.model.PermissionType
 import com.kiero.data.auth.repository.AuthRepository
@@ -9,6 +11,7 @@ import com.kiero.data.fcm.repository.FcmRepository
 import com.kiero.data.parent.journey.repository.ParentJourneyRepository
 import com.kiero.data.sse.manager.SseManager
 import com.kiero.data.sse.model.parent.SseScheduleEventType
+import com.kiero.presentation.parent.screen.journey.model.KidInfo
 import com.kiero.presentation.parent.screen.journey.model.TodayJourneyUiModel
 import com.kiero.presentation.parent.screen.journey.model.TodayStatus
 import com.kiero.presentation.parent.screen.journey.model.toUiModel
@@ -33,7 +36,8 @@ class ParentJourneyViewModel @Inject constructor(
     private val parentJourneyRepository: ParentJourneyRepository,
     private val sseManager: SseManager,
     private val fcmRepository: FcmRepository,
-    private val permissionInfoManager: PermissionInfoManager
+    private val permissionInfoManager: PermissionInfoManager,
+    private val userInfoManager: UserInfoManager
 ) : ViewModel() {
     private val _state = MutableStateFlow(ParentJourneyState())
     val state = _state.asStateFlow()
@@ -49,6 +53,9 @@ class ParentJourneyViewModel @Inject constructor(
         )
 
     private var hasShownInitialPrompt = false
+    private var hasStartedSseCollectors = false
+    private var isParentJourneyFetching = false
+    private var lastParentJourneyFetchAt = 0L
 
     init {
         fetchKidInfo()
@@ -79,6 +86,10 @@ class ParentJourneyViewModel @Inject constructor(
     }
 
     fun collectConnectionEvents() {
+        if (hasStartedSseCollectors) return
+
+        hasStartedSseCollectors = true
+
         viewModelScope.launch {
             sseManager.connectionState.collect { isConnected ->
                 if (isConnected) {
@@ -113,11 +124,35 @@ class ParentJourneyViewModel @Inject constructor(
 
     fun fetchKidInfo() {
         viewModelScope.launch {
+            val localChildId = userInfoManager.getChildIdInfo()
+            val localChildFirstName = userInfoManager.getChildFirstName().orEmpty()
+
+            if (localChildId != null) {
+                _state.update { currentState ->
+                    currentState.copy(
+                        kidInfo = KidInfo(
+                            kidId = localChildId.toString(),
+                            kidName = localChildFirstName
+                        )
+                    )
+                }
+
+                fetchParentJourney(localChildId)
+                collectParentJourneyScheduleEvents()
+                collectConnectionEvents()
+                return@launch
+            }
+
             authRepository.getChildren()
                 .onSuccess { response ->
                     val kidInfo = response.firstOrNull()?.toUiModel()
                     Timber.e("fetchKidInfo, $kidInfo")
                     if (kidInfo != null) {
+                        userInfoManager.saveChildIdInfo(kidInfo.kidId.toLong())
+                        userInfoManager.saveChildName(
+                            lastName = response.first().childLastName,
+                            firstName = response.first().childFirstName
+                        )
                         _state.update { currentState ->
                             currentState.copy(
                                 kidInfo = kidInfo
@@ -137,29 +172,41 @@ class ParentJourneyViewModel @Inject constructor(
     }
 
     fun fetchParentJourney(childId: Long) {
-        viewModelScope.launch {
-            parentJourneyRepository.getParentJourney(
-                childId = childId
-            ).onSuccess { result ->
-                val currentTime = LocalTime.now()
+        val now = SystemClock.elapsedRealtime()
+        if (isParentJourneyFetching || now - lastParentJourneyFetchAt < PARENT_JOURNEY_FETCH_THROTTLE_MS) {
+            return
+        }
 
-                _state.update { currentState ->
-                    currentState.copy(
-                        isFireLitToday = result.isFireLitToday,
-                        completeMissions = result.completeMissions.map { it.toUiModel() }.toImmutableList(),
-                        incompleteMissions = result.incompleteMissions.map { it.toUiModel() }.toImmutableList(),
-                        todayMissionList = if (result.isFireLitToday) {
-                            result.schedules.toUiModels(currentTime).toPersistentList().add(
-                                TodayJourneyUiModel(todayStatus = TodayStatus.TODAY_COMPLETED)
-                            )
-                        } else {
-                            result.schedules.toUiModels(currentTime).toPersistentList()
-                        }
-                    )
+        isParentJourneyFetching = true
+        lastParentJourneyFetchAt = now
+
+        viewModelScope.launch {
+            try {
+                parentJourneyRepository.getParentJourney(
+                    childId = childId
+                ).onSuccess { result ->
+                    val currentTime = LocalTime.now()
+
+                    _state.update { currentState ->
+                        currentState.copy(
+                            isFireLitToday = result.isFireLitToday,
+                            completeMissions = result.completeMissions.map { it.toUiModel() }.toImmutableList(),
+                            incompleteMissions = result.incompleteMissions.map { it.toUiModel() }.toImmutableList(),
+                            todayMissionList = if (result.isFireLitToday) {
+                                result.schedules.toUiModels(currentTime).toPersistentList().add(
+                                    TodayJourneyUiModel(todayStatus = TodayStatus.TODAY_COMPLETED)
+                                )
+                            } else {
+                                result.schedules.toUiModels(currentTime).toPersistentList()
+                            }
+                        )
+                    }
+                }.onFailure {
+                    Timber.e("parentJourney ${it.message.toString()}")
+                    _sideEffect.emit(ParentJourneySideEffect.ShowSnackbar(message = "일정 정보 불러오기에 실패하였습니다"))
                 }
-            }.onFailure {
-                Timber.e("parentJourney ${it.message.toString()}")
-                _sideEffect.emit(ParentJourneySideEffect.ShowSnackbar(message = "일정 정보 불러오기에 실패하였습니다"))
+            } finally {
+                isParentJourneyFetching = false
             }
         }
     }
@@ -186,5 +233,9 @@ class ParentJourneyViewModel @Inject constructor(
     override fun onCleared() {
         super.onCleared()
         sseManager.stopSubscription()
+    }
+
+    companion object {
+        private const val PARENT_JOURNEY_FETCH_THROTTLE_MS = 500L
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mission/viewmodel/ParentMissionViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mission/viewmodel/ParentMissionViewModel.kt
@@ -6,6 +6,7 @@ import com.kiero.core.localstorage.info.UserInfoManager
 import com.kiero.core.model.UiState
 import com.kiero.data.parent.mission.repository.MissionRepository
 import com.kiero.data.parent.mission.repository.ParentMissionAddRepository
+import com.kiero.data.sse.manager.SseManager
 import com.kiero.presentation.kid.mission.model.toUiModel
 import com.kiero.presentation.parent.screen.mission.state.ParentMissionSideEffect
 import com.kiero.presentation.parent.screen.mission.state.ParentMissionState
@@ -22,14 +23,32 @@ class ParentMissionViewModel @Inject constructor(
     private val missionRepository: MissionRepository,
     private val parentMissionAddRepository: ParentMissionAddRepository,
     private val userInfoManager: UserInfoManager,
+    private val sseManager: SseManager
 ) : ViewModel() {
-
     private val _state = MutableStateFlow<UiState<ParentMissionState>>(UiState.Loading)
     val state = _state.asStateFlow()
 
     private val _sideEffect = MutableSharedFlow<ParentMissionSideEffect>()
     val sideEffect = _sideEffect.asSharedFlow()
 
+    init {
+        collectParentMissionEvents()
+    }
+
+    private fun collectParentMissionEvents() {
+        viewModelScope.launch {
+            val childId = userInfoManager.getChildIdInfo() ?: run {
+                _state.value = UiState.Empty
+                return@launch
+            }
+
+            sseManager.parentMissionCompleteEvents.collect { event ->
+                if (event.data.childId == childId) {
+                    getMissions()
+                }
+            }
+        }
+    }
     fun getMissions() {
         viewModelScope.launch {
             val childId = userInfoManager.getChildIdInfo() ?: run {

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/ParentMyPageChildCareContract.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/ParentMyPageChildCareContract.kt
@@ -12,6 +12,7 @@ data class ParentMyPageChildCareState(
     val isLogoutDialogVisible: Boolean = false,
     val isExpired: Boolean = false,
     val isLoading: Boolean = false,
+    val isInitialized: Boolean = false,
 )
 
 sealed interface ParentMyPageChildCareSideEffect {

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/ParentMyPageChildCareScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/ParentMyPageChildCareScreen.kt
@@ -80,7 +80,7 @@ fun ParentMyPageChildCareScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(KieroTheme.colors.black)
-            .padding(paddingValues)
+            .padding(top = paddingValues.calculateTopPadding())
             .padding(horizontal = 16.dp, vertical = 13.dp)
     ) {
         KieroTopbar(
@@ -92,7 +92,8 @@ fun ParentMyPageChildCareScreen(
             ParentChildCareStep.MANAGEMENT -> {
                 ParentMyPageChildManagementScreen(
                     state = state,
-                    onReIssueClick = viewModel::onReIssueClick
+                    onReIssueClick = viewModel::onReIssueClick,
+                    modifier = Modifier.weight(1f)
                 )
             }
 
@@ -100,7 +101,8 @@ fun ParentMyPageChildCareScreen(
                 ParentMyPageChildInviteScreen(
                     state = state,
                     onCopyClick = viewModel::onCopyClick,
-                    onReIssueClick = viewModel::onReIssueClick
+                    onReIssueClick = viewModel::onReIssueClick,
+                    modifier = Modifier.weight(1f)
                 )
             }
         }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/ParentMyPageChildCareScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/ParentMyPageChildCareScreen.kt
@@ -4,6 +4,7 @@ import android.content.ClipData
 import android.os.Build
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -19,6 +20,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kiero.core.common.extension.collectSingleEvent
 import com.kiero.core.designsystem.component.KieroTopbar
+import com.kiero.core.designsystem.component.indicator.KieroLoadingIndicator
 import com.kiero.core.designsystem.theme.KieroTheme
 import com.kiero.core.model.trigger.SnackbarState
 import com.kiero.core.trigger.LocalGlobalUiEventTrigger
@@ -76,35 +78,45 @@ fun ParentMyPageChildCareScreen(
         viewModel.onBackClick()
     }
 
-    Column(
+    Box(
         modifier = Modifier
             .fillMaxSize()
             .background(KieroTheme.colors.black)
             .padding(top = paddingValues.calculateTopPadding())
             .padding(horizontal = 16.dp, vertical = 13.dp)
     ) {
-        KieroTopbar(
-            title = "자녀 관리",
-            leftIconClick = viewModel::onBackClick
-        )
+        Column(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            KieroTopbar(
+                title = "자녀 관리",
+                leftIconClick = viewModel::onBackClick
+            )
 
-        when(state.currentStep) {
-            ParentChildCareStep.MANAGEMENT -> {
-                ParentMyPageChildManagementScreen(
-                    state = state,
-                    onReIssueClick = viewModel::onReIssueClick,
-                    modifier = Modifier.weight(1f)
-                )
-            }
+            if (state.isInitialized) {
+                when(state.currentStep) {
+                    ParentChildCareStep.MANAGEMENT -> {
+                        ParentMyPageChildManagementScreen(
+                            state = state,
+                            onReIssueClick = viewModel::onReIssueClick,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
 
-            ParentChildCareStep.INVITE -> {
-                ParentMyPageChildInviteScreen(
-                    state = state,
-                    onCopyClick = viewModel::onCopyClick,
-                    onReIssueClick = viewModel::onReIssueClick,
-                    modifier = Modifier.weight(1f)
-                )
+                    ParentChildCareStep.INVITE -> {
+                        ParentMyPageChildInviteScreen(
+                            state = state,
+                            onCopyClick = viewModel::onCopyClick,
+                            onReIssueClick = viewModel::onReIssueClick,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                }
             }
+        }
+
+        if (!state.isInitialized || state.isLoading) {
+            KieroLoadingIndicator()
         }
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/ParentMyPageChildCareViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/ParentMyPageChildCareViewModel.kt
@@ -98,7 +98,8 @@ class ParentMyPageChildCareViewModel @Inject constructor(
                             isChildJoined = (childId != null)
                         ),
                         connectionStatus = ChildConnectionStatus.PENDING,
-                        currentStep = ParentChildCareStep.INVITE
+                        currentStep = ParentChildCareStep.INVITE,
+                        isInitialized = true
                     )
                 }
                 startTimer(expireTime)
@@ -115,7 +116,8 @@ class ParentMyPageChildCareViewModel @Inject constructor(
                             isChildJoined = true
                         ),
                         connectionStatus = ChildConnectionStatus.CONNECTED,
-                        currentStep = ParentChildCareStep.MANAGEMENT
+                        currentStep = ParentChildCareStep.MANAGEMENT,
+                        isInitialized = true
                     )
                 }
             }
@@ -131,7 +133,8 @@ class ParentMyPageChildCareViewModel @Inject constructor(
                             isChildJoined = false
                         ),
                         connectionStatus = ChildConnectionStatus.CONNECTED,
-                        currentStep = ParentChildCareStep.MANAGEMENT
+                        currentStep = ParentChildCareStep.MANAGEMENT,
+                        isInitialized = true
                     )
                 }
             }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/ParentMyPageChildCareViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/ParentMyPageChildCareViewModel.kt
@@ -39,6 +39,7 @@ class ParentMyPageChildCareViewModel @Inject constructor(
     private var timerJob: Job? = null
 
     private var lastCopyTime = 0L
+    private var shouldClearPendingInviteOnExit = false
 
     init {
         collectInviteEvents()
@@ -60,14 +61,17 @@ class ParentMyPageChildCareViewModel @Inject constructor(
 
     private suspend fun handleChildJoined(childId: Long) {
         userInfoManager.saveChildIdInfo(childId)
+        shouldClearPendingInviteOnExit = true
+        timerJob?.cancel()
         _state.update {
             it.copy(
                 connectionStatus = ChildConnectionStatus.CONNECTED,
-                // 연결완료시 management로 이동할지 말지? Todo
-                // currentStep = ParentChildCareStep.MANAGEMENT
+                isExpired = false,
+                childInfo = it.childInfo.copy(
+                    isChildJoined = true
+                )
             )
         }
-        timerJob?.cancel()
         _sideEffect.emit(ParentMyPageChildCareSideEffect.ShowSnackbar("자녀 연동이 완료되었습니다!"))
     }
 
@@ -94,7 +98,7 @@ class ParentMyPageChildCareViewModel @Inject constructor(
                             isChildJoined = (childId != null)
                         ),
                         connectionStatus = ChildConnectionStatus.PENDING,
-                        currentStep = ParentChildCareStep.MANAGEMENT
+                        currentStep = ParentChildCareStep.INVITE
                     )
                 }
                 startTimer(expireTime)
@@ -190,18 +194,26 @@ class ParentMyPageChildCareViewModel @Inject constructor(
         when (currentStep) {
             ParentChildCareStep.MANAGEMENT -> {
                 viewModelScope.launch {
+                    clearPendingInviteCodeIfChildJoined()
                     _sideEffect.emit(ParentMyPageChildCareSideEffect.NavigateToMyPage)
                 }
             }
 
             ParentChildCareStep.INVITE -> {
-                _state.update {
-                    it.copy(
-                        currentStep = ParentChildCareStep.MANAGEMENT
-                    )
+                viewModelScope.launch {
+                    clearPendingInviteCodeIfChildJoined()
+                    _sideEffect.emit(ParentMyPageChildCareSideEffect.NavigateToMyPage)
                 }
             }
         }
+    }
+
+    private suspend fun clearPendingInviteCodeIfChildJoined() {
+        if (!shouldClearPendingInviteOnExit) return
+
+        userInfoManager.clearPendingInviteCode()
+        shouldClearPendingInviteOnExit = false
+        timerJob?.cancel()
     }
 
     fun onReIssueClick() {

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/screen/ParentMyPageChildInviteScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/screen/ParentMyPageChildInviteScreen.kt
@@ -17,8 +17,11 @@ fun ParentMyPageChildInviteScreen(
     state: ParentMyPageChildCareState,
     onCopyClick: () -> Unit,
     onReIssueClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    Column {
+    Column(
+        modifier = modifier
+    ) {
         ParentMyPageChildNameHolder(
             childInfo = state.childInfo,
             connectionStatus = state.connectionStatus

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/screen/ParentMyPageChildManagementScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/childcare/screen/ParentMyPageChildManagementScreen.kt
@@ -1,33 +1,33 @@
 package com.kiero.presentation.parent.screen.mypage.childcare.screen
 
-import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kiero.core.designsystem.component.button.KieroButtonMedium
 import com.kiero.core.designsystem.theme.KieroTheme
 import com.kiero.presentation.parent.screen.mypage.childcare.ParentMyPageChildCareState
 import com.kiero.presentation.parent.screen.mypage.childcare.component.ParentMyPageChildNameHolder
-import com.kiero.presentation.parent.screen.mypage.model.ChildConnectionStatus
 
 @Composable
 fun ParentMyPageChildManagementScreen(
     state: ParentMyPageChildCareState,
     onReIssueClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
-            .background(KieroTheme.colors.black)
-            .animateContentSize(),
+            .background(KieroTheme.colors.black),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         ParentMyPageChildNameHolder(
@@ -40,19 +40,16 @@ fun ParentMyPageChildManagementScreen(
         Text(
             text = "아이가 다시 로그인해야 하는 경우, 연결 코드를 새로 발급해주세요.",
             style = KieroTheme.typography.regular.body4,
-            color = KieroTheme.colors.gray300
+            color = KieroTheme.colors.gray300,
+            modifier = Modifier
+                .fillMaxWidth(),
+            textAlign = TextAlign.Start
         )
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        val buttonText = if (state.connectionStatus == ChildConnectionStatus.PENDING && !state.isExpired) {
-            "연결 코드 확인"
-        } else {
-            "연결 코드 재발급"
-        }
-
         KieroButtonMedium(
-            text = buttonText,
+            text = "연결 코드 재발급",
             onClick = onReIssueClick,
             containerColor = KieroTheme.colors.main,
             contentColor = KieroTheme.colors.black

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/ParentMyPageContract.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/ParentMyPageContract.kt
@@ -9,7 +9,7 @@ import kotlinx.collections.immutable.persistentListOf
 data class ParentMyPageState(
     val parentInfo : ParentInfo = ParentInfo(),
     val myPageMenus : ImmutableList<ParentMyPageMenuUiModel> = persistentListOf(),
-    val connectionStatus: ChildConnectionStatus = ChildConnectionStatus.REISSUE,
+    val connectionStatus: ChildConnectionStatus? = null,
     val isAlarmChecked: Boolean = false
 )
 

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/ParentMyPageViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/ParentMyPageViewModel.kt
@@ -74,6 +74,10 @@ class ParentMyPageViewModel @Inject constructor(
         viewModelScope.launch {
             parentMyPageRepository.getParentMyProfile()
                 .onSuccess { response ->
+                    if (!response.hasPendingChildSession) {
+                        userInfoManager.clearPendingInviteCode()
+                    }
+
                     _state.update {
                         it.copy(
                             parentInfo = ParentInfo(

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/component/SettingItem.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mypage/main/component/SettingItem.kt
@@ -26,7 +26,7 @@ fun SettingItem(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    connectionStatus: ChildConnectionStatus = ChildConnectionStatus.REISSUE,
+    connectionStatus: ChildConnectionStatus? = null,
     showConnectionStatus: Boolean = false
 ) {
     Row(
@@ -44,7 +44,7 @@ fun SettingItem(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        if (showConnectionStatus) {
+        if (showConnectionStatus && connectionStatus != null) {
             val isPending = connectionStatus == ChildConnectionStatus.PENDING
 
             KieroChip(

--- a/app/src/main/java/com/kiero/presentation/parent/screen/schedule/plan/component/picker/TimePicker.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/schedule/plan/component/picker/TimePicker.kt
@@ -2,7 +2,6 @@ package com.kiero.presentation.parent.screen.schedule.plan.component.picker
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,12 +23,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -41,6 +40,7 @@ import com.kiero.core.designsystem.theme.KieroTheme
 import com.sonms.wheelpicker.VerticalWheelPicker
 import com.sonms.wheelpicker.state.rememberWheelPickerState
 import com.sonms.wheelpicker.style.WheelPickerDefaults
+import kotlinx.coroutines.launch
 
 @Composable
 fun TimePicker(
@@ -129,17 +129,13 @@ fun TimePickerBottomSheet(
         containerColor = KieroTheme.colors.gray900,
         dragHandle = {},
         modifier = modifier
-            .pointerInput(Unit) {
-                detectTapGestures {
-                    onDismissRequest()
-                }
-            }
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(vertical = 16.dp)
                 .disableNestedScroll()
+                .disableUpWardEvent()
         ) {
             PickerTopbar(
                 title = pickerTitle,
@@ -224,6 +220,7 @@ fun TimeSelectionSection(
     val minuteState = rememberWheelPickerState(initialIndex = minuteIndex)
     val amPmState = rememberWheelPickerState(initialIndex = amPmIndex)
 
+    val scope = rememberCoroutineScope()
     val itemHeight = 44.dp
 
     Box(
@@ -263,7 +260,18 @@ fun TimeSelectionSection(
                 ),
                 onItemSelected = { _, item -> onHourChosen(item) },
             ) { item, isSelected ->
-                TimePickerItem(text = item, isSelected = isSelected)
+                TimePickerItem(
+                    text = item,
+                    isSelected = isSelected,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(itemHeight),
+                    onClick = {
+                        scope.launch {
+                            hourState.animateScrollToIndex(TimePickerConstants.hours.indexOf(item))
+                        }
+                    }
+                )
             }
 
             Spacer(modifier = Modifier.width(16.dp))
@@ -284,7 +292,18 @@ fun TimeSelectionSection(
                 ),
                 onItemSelected = { _, item -> onMinuteChosen(item) },
             ) { item, isSelected ->
-                TimePickerItem(text = item, isSelected = isSelected)
+                TimePickerItem(
+                    text = item,
+                    isSelected = isSelected,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(itemHeight),
+                    onClick = {
+                        scope.launch {
+                            minuteState.animateScrollToIndex(TimePickerConstants.minutes.indexOf(item))
+                        }
+                    }
+                )
             }
 
             Spacer(modifier = Modifier.width(16.dp))
@@ -305,7 +324,18 @@ fun TimeSelectionSection(
                 ),
                 onItemSelected = { _, item -> onAmPmChosen(item) },
             ) { item, isSelected ->
-                TimePickerItem(text = item, isSelected = isSelected)
+                TimePickerItem(
+                    text = item,
+                    isSelected = isSelected,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(itemHeight),
+                    onClick = {
+                        scope.launch {
+                            amPmState.animateScrollToIndex(TimePickerConstants.amPmList.indexOf(item))
+                        }
+                    }
+                )
             }
         }
     }
@@ -315,13 +345,20 @@ fun TimeSelectionSection(
 private fun TimePickerItem(
     text: String,
     isSelected: Boolean,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
 ) {
-    Text(
-        text = text,
-        color = if (isSelected) KieroTheme.colors.white else KieroTheme.colors.gray600,
-        style = KieroTheme.typography.semiBold.title2,
-        textAlign = TextAlign.Center,
-    )
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier.noRippleClickable(onClick = onClick),
+    ) {
+        Text(
+            text = text,
+            color = if (isSelected) KieroTheme.colors.white else KieroTheme.colors.gray600,
+            style = KieroTheme.typography.semiBold.title2,
+            textAlign = TextAlign.Center,
+        )
+    }
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/kiero/presentation/splash/viewmodel/SplashViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/splash/viewmodel/SplashViewModel.kt
@@ -8,7 +8,6 @@ import com.kiero.core.localstorage.info.UserInfoManager
 import com.kiero.core.localstorage.onboarding.OnboardingManager
 import com.kiero.core.model.auth.UserRole
 import com.kiero.core.network.auth.TokenRefreshService
-import com.kiero.data.kid.mypage.repository.KidMyPageRepository
 import com.kiero.domain.kid.user.usecase.CheckParentStatusUseCase
 import com.kiero.domain.parent.splash.model.ParentAutoLoginResult
 import com.kiero.domain.parent.splash.usecase.CheckParentAutoLoginUseCase
@@ -34,21 +33,6 @@ class SplashViewModel @Inject constructor(
     private val _sideEffect = Channel<SplashSideEffect>()
     val sideEffect = _sideEffect.receiveAsFlow()
 
-
-    fun checkParentStatus() {
-        viewModelScope.launch {
-            checkParentStatusUseCase()
-                .onSuccess {
-                    if (it) {
-                        userInfoManager.clearKidInfo()
-                        appRestarter.restartApp()
-                    }
-                }
-                .onFailure {
-                    Timber.e("checkParentStatus failed $it")
-                }
-        }
-    }
     fun checkLoginState() {
         viewModelScope.launch {
             delay(2000)
@@ -56,8 +40,13 @@ class SplashViewModel @Inject constructor(
             val accessToken = tokenManager.getAccessToken()
             val userRole = userInfoManager.getUserRole()
             val refreshToken = tokenManager.getRefreshToken()
+            val isRequiredTermsAllAgreed = userInfoManager.getTermsInfo() ?: false
 
-            if (!accessToken.isNullOrBlank() && userRole != null && !refreshToken.isNullOrBlank()) {
+            val isParentAndAgreed = userRole == UserRole.PARENT && isRequiredTermsAllAgreed
+            val isKid = userRole == UserRole.KID
+
+            // 토큰이 존재하면서 (부모+동의완료) 이거나 (자녀)인 경우
+            if (!accessToken.isNullOrBlank() && userRole != null && !refreshToken.isNullOrBlank() && (isParentAndAgreed || isKid)) {
                 reIssueManager.refresh(
                     refreshToken = refreshToken,
                     role = userRole
@@ -71,6 +60,7 @@ class SplashViewModel @Inject constructor(
                     _sideEffect.send(SplashSideEffect.NavigateToAuth)
                 }
             } else {
+                // 토큰이 없거나 부모인데 약관 동의를 안 한 경우 인증 화면으로 이동
                 _sideEffect.send(SplashSideEffect.NavigateToAuth)
             }
         }

--- a/app/src/main/java/com/kiero/presentation/splash/viewmodel/SplashViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/splash/viewmodel/SplashViewModel.kt
@@ -40,13 +40,12 @@ class SplashViewModel @Inject constructor(
             val accessToken = tokenManager.getAccessToken()
             val userRole = userInfoManager.getUserRole()
             val refreshToken = tokenManager.getRefreshToken()
-            val isRequiredTermsAllAgreed = userInfoManager.getTermsInfo() ?: false
 
-            val isParentAndAgreed = userRole == UserRole.PARENT && isRequiredTermsAllAgreed
+            val isParent = userRole == UserRole.PARENT
             val isKid = userRole == UserRole.KID
 
-            // 토큰이 존재하면서 (부모+동의완료) 이거나 (자녀)인 경우
-            if (!accessToken.isNullOrBlank() && userRole != null && !refreshToken.isNullOrBlank() && (isParentAndAgreed || isKid)) {
+            // 토큰이 존재하면 부모는 서버 약관 상태를 다시 확인하고, 자녀는 기존 온보딩 상태를 확인
+            if (!accessToken.isNullOrBlank() && userRole != null && !refreshToken.isNullOrBlank() && (isParent || isKid)) {
                 reIssueManager.refresh(
                     refreshToken = refreshToken,
                     role = userRole


### PR DESCRIPTION
## ISSUE
- closed #184 

## ❗ WORK DESCRIPTION
- SP2의 QA 시트 내용을 반영하였습니다

- 부모 SSE 이벤트 빠진거 추가하였습니다

- API 중복 호출을 최소화 하였습니다
ParentJourneyScreen에서 최초 ON_RESUME 시의 중복 호출을 방지하기 위해 스킵 로직 추가
ViewModel에서 유저 정보(자녀 ID, 이름)를 UserInfoManager를 통해 로컬 캐싱 및 우선 로드하도록 변경
SSE 수집기(collector)의 중복 실행 방지 로직 추가
fetchParentJourney API 호출 시 쓰로틀링(500ms) 및 로딩 상태 체크 로직을 추가하여 무분별한 요청 방지

- 사용자 UX 강화
마이페이지에서 Default 값을 null로 두어 칩의 상태 변경이 급격하게 변경되는 것을 방지
ChildCare 화면에서 렌더링 되는 동안 화면 상태 계산 시 발생하는 현상 수정


## 📢 TO REVIEWERS
- 아자잣!