### PR TITLE
[mod/#185] SP2 푸시알람 QA-2

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,10 @@
             android:name="com.google.firebase.messaging.default_notification_icon"
             android:resource="@drawable/ic_push_notification" />
 
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="kiero_push_channel" />
+
         <service
             android:name="com.kiero.core.fcm.KieroFcmService"
             android:exported="false">

--- a/app/src/main/java/com/kiero/core/fcm/FcmService.kt
+++ b/app/src/main/java/com/kiero/core/fcm/FcmService.kt
@@ -19,13 +19,13 @@ class KieroFcmService : FirebaseMessagingService() {
 
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
-        Timber.d("푸시 알림 수신: ${message.data}")
+        Timber.d("푸시 알림 수신 (data): ${message.data}")
 
-        val title = message.notification?.title
-        val body = message.notification?.body
+        val title = message.data["title"] ?: message.notification?.title
+        val body = message.data["body"] ?: message.notification?.body
 
         if (title.isNullOrEmpty() || body.isNullOrEmpty()) {
-            Timber.w("푸시 알림의 제목이나 내용이 비어있어 무시합니다. (title: $title, body: $body)")
+            Timber.w("푸시 알림의 제목이나 내용이 비어있어 무시합니다. (전달된 data: ${message.data})")
             return
         }
 

--- a/app/src/main/java/com/kiero/core/notification/KieroNotificationManager.kt
+++ b/app/src/main/java/com/kiero/core/notification/KieroNotificationManager.kt
@@ -58,8 +58,11 @@ class KieroNotificationManager @Inject constructor(
             .setStyle(NotificationCompat.BigTextStyle().bigText(body))
             .setAutoCancel(true)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setDefaults(NotificationCompat.DEFAULT_ALL)
             .setContentIntent(pendingIntent)
             .setColor(ContextCompat.getColor(context, R.color.kiero_mint))
+            .setGroup("KIERO_PUSH_GROUP")
+            .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_ALL)
 
         val uniqueId = System.currentTimeMillis().toInt()
 

--- a/app/src/main/java/com/kiero/presentation/auth/kid/KidSignupViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/auth/kid/KidSignupViewModel.kt
@@ -2,14 +2,13 @@ package com.kiero.presentation.auth.kid
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.kiero.core.common.extension.toHandleErrorMessage
 import com.kiero.core.localstorage.TokenManager
 import com.kiero.data.auth.repository.AuthRepository
+import com.kiero.data.fcm.repository.FcmRepository
 import com.kiero.presentation.auth.kid.model.toModel
 import com.kiero.presentation.auth.kid.state.KidSignUpState
 import com.kiero.presentation.auth.kid.state.KidSignupSideEffect
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -23,7 +22,8 @@ import javax.inject.Inject
 @HiltViewModel
 class KidSignupViewModel @Inject constructor(
     private val authRepository: AuthRepository,
-    private val tokenRepository: TokenManager
+    private val tokenRepository: TokenManager,
+    private val fcmRepository: FcmRepository
 ) : ViewModel() {
     private val _state = MutableStateFlow(KidSignUpState())
     val state: StateFlow<KidSignUpState> = _state.asStateFlow()
@@ -60,6 +60,10 @@ class KidSignupViewModel @Inject constructor(
                     accessToken = authResponse.accessToken,
                     refreshToken = authResponse.refreshToken
                 )
+
+                fcmRepository.syncFcmToken()
+                    .onSuccess { Timber.d("아이 로그인 직후 FCM 동기화 성공!") }
+                    .onFailure { Timber.e(it, "아이 FCM 동기화 실패") }
 
                 _sideEffect.emit(KidSignupSideEffect.NavigateToKidOnboarding)
             }.onFailure {

--- a/app/src/main/java/com/kiero/presentation/auth/parent/viewmodel/AuthParentViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/auth/parent/viewmodel/AuthParentViewModel.kt
@@ -9,6 +9,7 @@ import com.kiero.core.common.extension.toHandleErrorMessage
 import com.kiero.core.localstorage.info.UserInfoManager
 import com.kiero.core.model.UiState
 import com.kiero.data.auth.repository.AuthRepository
+import com.kiero.data.fcm.repository.FcmRepository
 import com.kiero.data.terms.repository.TermsRepository
 import com.kiero.domain.login.HandleKakaoLoginResultUseCase
 import com.kiero.domain.login.model.KakaoLoginResult
@@ -34,6 +35,7 @@ class AuthParentViewModel @Inject constructor(
     private val termsRepository: TermsRepository,
     private val userInfoManager: UserInfoManager,
     private val handleKakaoLoginResultUseCase: HandleKakaoLoginResultUseCase,
+    private val fcmRepository: FcmRepository
 ) : ViewModel() {
     private val _state = MutableStateFlow(AuthParentState())
     val state: StateFlow<AuthParentState> = _state.asStateFlow()
@@ -52,10 +54,15 @@ class AuthParentViewModel @Inject constructor(
                 ).onSuccess { domainResult: KakaoLoginResult ->
                     when (domainResult) {
                         is KakaoLoginResult.NeedTermsAgreement -> showTermsAgreement()
-                        is KakaoLoginResult.HasChildren -> _sideEffect.emit(AuthSideEffect.NavigateToParentGraph)
-                        is KakaoLoginResult.NoChildren -> _sideEffect.emit(AuthSideEffect.NavigateToParentSignUp)
+                        is KakaoLoginResult.HasChildren -> {
+                            syncFcmToken()
+                            _sideEffect.emit(AuthSideEffect.NavigateToParentGraph)
+                        }
+                        is KakaoLoginResult.NoChildren -> {
+                            syncFcmToken()
+                            _sideEffect.emit(AuthSideEffect.NavigateToParentSignUp)
+                        }
                     }
-
                 }.onFailure { throwable ->
                     Timber.e(throwable)
                     handleError(throwable)
@@ -75,6 +82,14 @@ class AuthParentViewModel @Inject constructor(
         viewModelScope.launch {
             _sideEffect.emit(AuthSideEffect.NavigateToSelection)
             _state.update { it.copy(uiState = UiState.Empty) }
+        }
+    }
+
+    private fun syncFcmToken() {
+        viewModelScope.launch {
+            fcmRepository.syncFcmToken()
+                .onSuccess { Timber.d("부모 로그인 완료: FCM 동기화 성공!") }
+                .onFailure { Timber.e(it, "부모 FCM 동기화 실패") }
         }
     }
 

--- a/app/src/main/java/com/kiero/presentation/main/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/main/viewmodel/MainViewModel.kt
@@ -75,8 +75,14 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    private fun syncFcmToken() {
+    fun syncFcmToken() {
         viewModelScope.launch {
+            val userRole = userInfoManager.getUserRole()
+            if (userRole == null) {
+                Timber.w("로그인 정보(JWT)가 아직 없어 FCM 토큰 동기화를 보류합니다.")
+                return@launch
+            }
+
             fcmRepository.syncFcmToken()
                 .onSuccess {
                     Timber.d("FCM 토큰 동기화(획득 및 서버 갱신) 성공")

--- a/app/src/main/java/com/kiero/presentation/parent/screen/schedule/plan/viewmodel/ParentPlanViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/schedule/plan/viewmodel/ParentPlanViewModel.kt
@@ -253,6 +253,8 @@ class ParentPlanViewModel @Inject constructor(
     private fun onAddPlanClick() {
         if (_state.value.isLoading) return
 
+        _state.update { it.copy(isLoading = true) }
+
         viewModelScope.launch {
             val name = textState.text.toString().trim()
             val current = _state.value
@@ -267,6 +269,7 @@ class ParentPlanViewModel @Inject constructor(
                     referenceDate = current.currentReferenceDate
                 ).getOrElse {
                     _sideEffect.emit(ShowSnackBar("일정 저장에 실패했어요. 잠시 후 다시 시도해주세요."))
+                    _state.update { it.copy(isLoading = false) }
                     return@launch
                 }
             } else {
@@ -283,10 +286,9 @@ class ParentPlanViewModel @Inject constructor(
 
             if (validationErrors.isNotEmpty()) {
                 _sideEffect.emit(ShowSnackBar(validationErrors.first()))
+                _state.update { it.copy(isLoading = false) }
                 return@launch
             }
-
-            _state.update { it.copy(isLoading = true) }
 
             val serverStartTime = current.formatTimeForServer(current.startTime)
             val serverEndTime = current.formatTimeForServer(current.endTime)
@@ -322,6 +324,7 @@ class ParentPlanViewModel @Inject constructor(
                 _sideEffect.emit(ShowSnackBar(message))
                 delay(200)
                 _sideEffect.emit(navigateUp)
+                _state.update { it.copy(isLoading = false) }
             }.onFailure { throwable ->
                 val serverMessage = throwable.message.orEmpty()
 


### PR DESCRIPTION
## ISSUE
- closed #185 

## ❗ WORK DESCRIPTION

- fcmNotificationManger, fcm service
알람 수신시 -> 포그라운드,백그라운드 상관없이 상태창에 알람이 쌓여있으면 팝업이 안뜨는 문제를 수정했습니다.
payload 형식 변경 요청 후, fcm service 쪽에 data 내부에서 값을 우선적으로  받아오고 notification 에 대한 방어 구조로 변경하였습니다.
fcmNotificationManager 내부 builder 쪽에  setGroup,setGroupAlertBehavior 속성을 추가해 팝업을 모두 노출가능하게 변경했습니다.

- parentplanviewmodel
일정 중복요청을 막기 위한 로직을 수정하였습니다.

- manifest
알람 백그라운드 팝업 처리를 위해 channel 을 등록하였습니다.

- Fcm 토큰 등록시 jwt 토큰이 누락되는 사항을 수정했습니다.

## 📢 TO REVIEWERS
- sp2 도 곧이구만 키안드 수고많았으!

## 📸 SCREENSHOT
<img src="" width="300" />
<!-- video src="" witdh="300"/>-->
