### PR TITLE
[mod/#183] SP2 자녀 QA-2

### DIFF
--- a/app/src/main/java/com/kiero/presentation/kid/myspace/KidMySpaceScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/myspace/KidMySpaceScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -50,17 +51,22 @@ fun KidMySpaceRoute(
     val context = LocalContext.current
 
     var isWaitingForSettingsResult by remember { mutableStateOf(false) }
+    var hasOsPermission by remember {
+        mutableStateOf(PermissionChecker.isGranted(context, PermissionType.POST_NOTIFICATIONS))
+    }
 
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
-        val hasOsPermission = PermissionChecker.isGranted(context, PermissionType.POST_NOTIFICATIONS)
+        hasOsPermission = PermissionChecker.isGranted(context, PermissionType.POST_NOTIFICATIONS)
 
         if (isWaitingForSettingsResult) {
             viewModel.onNotificationToggle(hasOsPermission)
             isWaitingForSettingsResult = false
-        } else {
-            if (!hasOsPermission && state.isNotificationChecked) {
-                viewModel.onNotificationToggle(false)
-            }
+        }
+    }
+
+    LaunchedEffect(hasOsPermission, state.isNotificationChecked) {
+        if (!hasOsPermission && state.isNotificationChecked) {
+            viewModel.onNotificationToggle(false)
         }
     }
 

--- a/app/src/main/java/com/kiero/presentation/kid/myspace/KidMySpaceScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/myspace/KidMySpaceScreen.kt
@@ -166,7 +166,7 @@ private fun KidMySpaceScreen(
             isDisabled = false,
             onDismiss = onNotificationDialogDismiss,
             title = "설정에서 알림을 켜줘!",
-            subDescription = "알림을 받으려면 설정에서 키어로 알림을 허용해줘!",
+            subDescription = "알림을 받으려면\n설정에서 키어로 알림을 허용해줘!",
             cancelAction = KieroCancelAction(
                 text = "취소",
                 onClick = onNotificationDialogDismiss

--- a/app/src/main/java/com/kiero/presentation/kid/myspace/viewmodel/KidMySpaceViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/myspace/viewmodel/KidMySpaceViewModel.kt
@@ -4,8 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kiero.core.app.AppRestarter
 import com.kiero.core.localstorage.info.UserInfoManager
-import com.kiero.core.localstorage.permission.PermissionInfoManager
-import com.kiero.core.permission.model.PermissionType
 import com.kiero.data.auth.repository.AuthRepository
 import com.kiero.data.fcm.repository.FcmRepository
 import com.kiero.data.kid.coin.repository.CoinRepository
@@ -25,7 +23,6 @@ class KidMySpaceViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val userInfoManager: UserInfoManager,
     private val appRestarter: AppRestarter,
-    private val permissionInfoManager: PermissionInfoManager,
     private val fcmRepository: FcmRepository
 ) : ViewModel() {
 
@@ -34,7 +31,6 @@ class KidMySpaceViewModel @Inject constructor(
 
     init {
         fetchKidName()
-        observeNotificationDeniedCount()
         fetchPushSetting()
     }
 
@@ -63,20 +59,6 @@ class KidMySpaceViewModel @Inject constructor(
         }
     }
 
-    private fun observeNotificationDeniedCount() {
-        viewModelScope.launch {
-            permissionInfoManager.deniedCount(PermissionType.POST_NOTIFICATIONS).collect { count ->
-                _uiState.update { it.copy(permissionNotificationDeniedCount = count) }
-            }
-        }
-    }
-
-    fun increaseDeniedCount(type: PermissionType) {
-        viewModelScope.launch {
-            permissionInfoManager.increaseDeniedCount(type)
-        }
-    }
-
     private fun fetchPushSetting() {
         viewModelScope.launch {
             fcmRepository.getPushSetting()
@@ -89,11 +71,13 @@ class KidMySpaceViewModel @Inject constructor(
         }
     }
 
-   fun onNotificationToggle(checked: Boolean) {
+    fun onNotificationToggle(checked: Boolean) {
+        _uiState.update { it.copy(isNotificationChecked = checked) }
+
         viewModelScope.launch {
             fcmRepository.updatePushSetting(checked)
                 .onSuccess {
-                   _uiState.update { it.copy(isNotificationChecked = checked) }
+                    Timber.d("푸시 알림 서버 동기화 성공: $checked")
                 }
                 .onFailure { error ->
                     Timber.e("푸시 알림 설정 변경 실패: $error")
@@ -103,9 +87,5 @@ class KidMySpaceViewModel @Inject constructor(
 
     fun showNotificationDialog(show: Boolean) {
         _uiState.update { it.copy(showNotificationDialog = show) }
-    }
-
-    fun onNotificationDialogDismiss() {
-        _uiState.update { it.copy(showNotificationDialog = false) }
     }
 }

--- a/app/src/main/java/com/kiero/presentation/kid/myspace/wisharchive/component/KidMySpaceWishArchiveItem.kt
+++ b/app/src/main/java/com/kiero/presentation/kid/myspace/wisharchive/component/KidMySpaceWishArchiveItem.kt
@@ -36,7 +36,7 @@ fun KidMySpaceWishArchiveItem(
     price: Int = 0,
     onActionClick: () -> Unit = {}
 ) {
-    val displayTitle = if (hasWish) title else "오늘 아직 소원이 없어!"
+    val displayTitle = if (hasWish) title else "아직 빌었던 소원이 없어!"
     val displaySubtitle = if (hasWish) "획득일 | $date" else "오늘의 소원을 빌어볼까?"
 
 


### PR DESCRIPTION
## ISSUE
- closed #183

## ❗ WORK DESCRIPTION
SP2의 QA 시트 내용을 반영하였습니다

나의 공간
- 알림 설정 토글 로직 수정 및 OS 권한 동기화 방식 개선
- 사용자가 화면을 이탈하여 기기 자체 설정 앱으로 이동한 뒤, 앱의 알림 권한을 '거부(OFF)'로 변경하고 다시 앱으로 돌아왔을 때, 토글이 OFF로 갱신되지 않고 여전히 ON으로 켜져 있는 현상
- https://app.notion.com/p/x-3758ff4aed3f8082969cc0467a7ffacc
- https://app.notion.com/p/OS-3766e111864080c58040e6d0f0578481

오늘의 여정
- 마지막 여정 인증하고 [여정 끝내기] 버튼을 누르면 + 여정 시간이 끝났을때 마음의 불꽃 피워주기 버튼이 떠야 함
- 서버 로직 변경으로 해결(안드 코드 변경 x)
- https://app.notion.com/p/3758ff4aed3f80cf9ac5ca2258027a5b

소원의 공간
- 오늘 빈 소원이 없을 때, 문구 수정
- https://app.notion.com/p/3758ff4aed3f803b8fbfccdc2f8362f9

나의 공간
- 알림 다이얼로그 문구 개행 추가


## 📢 TO REVIEWERS
- 아자자

## 📸 SCREENSHOT
<img src="" width="300" />
<!-- video src="" witdh="300"/>-->
