### PR TITLE
[Mod#200] 앱 업데이트 판별 및 스플래시 화면 동작 개선

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="21" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -6,7 +6,7 @@
       <GradleProjectSettings>
         <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
+        <option name="gradleJvm" value="17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="zulu-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/kiero/core/designsystem/component/dialog/KieroDialog.kt
+++ b/app/src/main/java/com/kiero/core/designsystem/component/dialog/KieroDialog.kt
@@ -83,7 +83,9 @@ fun KieroDialog(
                         tint = Color.Unspecified,
                         modifier = Modifier
                             .alpha(if (isDisabled) 0f else 1f)
-                            .noRippleClickable(onClick = onDismiss)
+                            .then(
+                                if (isDisabled) Modifier else Modifier.noRippleClickable(onClick = onDismiss)
+                            )
                     )
                 }
 

--- a/app/src/main/java/com/kiero/data/config/constant/ConfigConstants.kt
+++ b/app/src/main/java/com/kiero/data/config/constant/ConfigConstants.kt
@@ -1,6 +1,6 @@
 package com.kiero.data.config.constant
 
-const val DEBUG_MIN_FETCH_INTERVAL_SECONDS = 5L * 60L
+const val DEBUG_MIN_FETCH_INTERVAL_SECONDS = 1L * 60L
 const val RELEASE_MIN_FETCH_INTERVAL_SECONDS = 60L * 60L // https://firebase.google.com/docs/remote-config/android/get-started 예제의 1시간 값
 
 const val KEY_MIN_FORCE_VERSION = "android_min_force_version"

--- a/app/src/main/java/com/kiero/data/config/remote/datasourceimpl/RemoteConfigDataSourceImpl.kt
+++ b/app/src/main/java/com/kiero/data/config/remote/datasourceimpl/RemoteConfigDataSourceImpl.kt
@@ -10,6 +10,7 @@ import com.kiero.data.config.constant.RELEASE_MIN_FETCH_INTERVAL_SECONDS
 import com.kiero.data.config.model.AppVersion
 import com.kiero.data.config.model.AppVersionInfo
 import com.kiero.data.config.remote.datasource.ConfigRemoteDataSource
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.tasks.await
@@ -24,12 +25,7 @@ class RemoteConfigDataSourceImpl @Inject constructor(
 
     override suspend fun getAppVersionInfo(): AppVersionInfo {
         initialize()
-
-        runCatching {
-            remoteConfig.fetchAndActivate().await()
-        }.onFailure { throwable ->
-            Timber.w(throwable, "Remote Config fetch failed. Using the active or in-app defaults.")
-        }
+        fetchAndActivateWithRetry()
 
         val currentVersion = AppVersion(BuildConfig.VERSION_NAME)
         val minForceVersion = getConfiguredVersion(KEY_MIN_FORCE_VERSION, currentVersion)
@@ -43,6 +39,20 @@ class RemoteConfigDataSourceImpl @Inject constructor(
 
     private fun getConfiguredVersion(key: String, fallback: AppVersion): AppVersion =
         AppVersion(remoteConfig.getString(key)).takeIf(AppVersion::isValid) ?: fallback
+
+    private suspend fun fetchAndActivateWithRetry() {
+        repeat(FETCH_ATTEMPT_COUNT) { attempt ->
+            val result = runCatching { remoteConfig.fetchAndActivate().await() }
+            if (result.isSuccess) return
+
+            val throwable = result.exceptionOrNull()
+            if (attempt == FETCH_ATTEMPT_COUNT - 1) {
+                Timber.w(throwable, "Remote Config fetch failed. Using the active or in-app defaults.")
+            } else {
+                delay(FETCH_RETRY_DELAY_MILLIS)
+            }
+        }
+    }
 
     private suspend fun initialize() {
         initializationMutex.withLock {
@@ -71,5 +81,10 @@ class RemoteConfigDataSourceImpl @Inject constructor(
                 Timber.w(throwable, "Remote Config initialization failed.")
             }
         }
+    }
+
+    private companion object {
+        private const val FETCH_ATTEMPT_COUNT = 2
+        private const val FETCH_RETRY_DELAY_MILLIS = 300L
     }
 }

--- a/app/src/main/java/com/kiero/presentation/splash/SplashScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/splash/SplashScreen.kt
@@ -1,5 +1,6 @@
 package com.kiero.presentation.splash
 
+import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -47,6 +48,7 @@ fun SplashRoute(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    val activity = LocalActivity.current
 
     viewModel.sideEffect.collectSingleEvent {
         when (it) {
@@ -68,7 +70,8 @@ fun SplashRoute(
         AppUpdateDialog(
             updateState = state.updateState,
             onConfirm = { context.navigateToPlayStore() },
-            onDismiss = { viewModel.checkLoginState() },
+            onDismiss = { viewModel.dismissUpdateDialog() },
+            onForceExit = { activity?.finishAffinity() },
         )
     }
 }

--- a/app/src/main/java/com/kiero/presentation/splash/component/AppUpdateDialog.kt
+++ b/app/src/main/java/com/kiero/presentation/splash/component/AppUpdateDialog.kt
@@ -14,12 +14,14 @@ fun AppUpdateDialog(
     updateState: UpdateState,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
+    onForceExit: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val isForce = updateState == UpdateState.FORCE
 
     KieroDialog(
-        onDismiss = if (isForce) ({}) else onDismiss,
+        // 강제 업데이트일 땐 뒤로가기/바깥 터치로 닫으려는 시도 자체를 앱 종료로 처리한다.
+        onDismiss = if (isForce) onForceExit else onDismiss,
         modifier = modifier,
         title = "새로운 업데이트가 있어요",
         subDescription = if (isForce) {

--- a/app/src/main/java/com/kiero/presentation/splash/viewmodel/SplashViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/splash/viewmodel/SplashViewModel.kt
@@ -10,6 +10,7 @@ import com.kiero.core.localstorage.info.UserInfoManager
 import com.kiero.core.localstorage.onboarding.OnboardingManager
 import com.kiero.core.model.auth.UserRole
 import com.kiero.core.network.auth.TokenRefreshService
+import com.kiero.core.network.monitor.NetworkMonitor
 import com.kiero.data.config.model.AppVersion
 import com.kiero.data.config.model.UpdateState
 import com.kiero.data.config.repository.ConfigRepository
@@ -23,9 +24,11 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
@@ -41,6 +44,7 @@ class SplashViewModel @Inject constructor(
     private val checkParentAutoLoginUseCase: CheckParentAutoLoginUseCase,
     private val configRepository: ConfigRepository,
     private val appRestarter: AppRestarter,
+    private val networkMonitor: NetworkMonitor,
 ) : ViewModel() {
     private val _state = MutableStateFlow(SplashState())
     val state = _state.asStateFlow()
@@ -84,15 +88,30 @@ class SplashViewModel @Inject constructor(
         val currentVersion = AppVersion(BuildConfig.VERSION_NAME)
 
         viewModelScope.launch {
+            // 콜드스타트 직후엔 네트워크 인터페이스/DNS가 아직 준비되지 않았을 수 있어,
+            // 짧게 온라인 상태를 기다렸다가 요청 (끝내 안 잡히면 타임아웃 후 그냥 진행)
+            withTimeoutOrNull(NETWORK_READY_TIMEOUT) {
+                networkMonitor.isOnline.first { it }
+            }
+
             configRepository.getAppVersionInfo()
                 .onSuccess { info ->
                     val state = info.checkUpdateState(currentVersion)
+
+                    Timber.d("checkAppVersion: $state, $info")
+
                     _state.update { it.copy(updateState = state) }
 
                     if (state == UpdateState.NONE) checkLoginState()
                 }
                 .onFailure { checkLoginState() }
         }
+    }
+
+    fun dismissUpdateDialog() {
+        // 다이얼로그를 먼저 닫은 뒤에 로그인 상태 체크(화면 전환)로 넘어간다.
+        _state.update { it.copy(updateState = UpdateState.NONE) }
+        checkLoginState()
     }
 
     private suspend fun handleParentLogin() {
@@ -131,5 +150,9 @@ class SplashViewModel @Inject constructor(
         } else {
             _sideEffect.send(SplashSideEffect.NavigateToKidOnboarding)
         }
+    }
+
+    private companion object {
+        private val NETWORK_READY_TIMEOUT = 2.seconds
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,6 @@ android.nonTransitiveRClass=true
 
 # Use AGP built-in Kotlin support
 android.builtInKotlin=true
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
## ISSUE
- closed #200

## ❗ WORK DESCRIPTION
- Remote Config 패치 로직에 네트워크 상태 연결 대기 및 재시도(Retry) 처리 추가
- Remote Config 디버그 패치 최소 주기 단축 (5분 -> 1분)
- 강제 업데이트 다이얼로그 닫기 시 앱 종료(`finishAffinity`) 로직 추가
- 업데이트 다이얼로그 해제 시 업데이트 상태를 `NONE`으로 변경한 후 로그인 상태를 검사하도록 개선
- `KieroDialog` 비활성화(`isDisabled`) 상태 시 닫기 아이콘의 클릭 이벤트가 동작하지 않도록 보완

## 📢 TO REVIEWERS
- 리뷰어에게 전달해야 하는 말

## 📸 SCREENSHOT
<img src="" width="300" />
<!-- video src="" witdh="300"/>-->
