### PR TITLE
[Mod/#202] TextFieldState 리팩토링

### DIFF
--- a/app/src/main/java/com/kiero/core/common/state/ClampedNumberFieldState.kt
+++ b/app/src/main/java/com/kiero/core/common/state/ClampedNumberFieldState.kt
@@ -1,0 +1,60 @@
+package com.kiero.core.common.state
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.runtime.Stable
+
+/**
+ * [min]~[max] 범위를 갖는 숫자 입력 필드의 상태 홀더.
+ *
+ * TextFieldState 와 그 필드에 필요한 보정 규칙을 한 곳에 묶어서,
+ * ViewModel 이 필드마다 같은 클램핑 코드를 반복하지 않도록 한다.
+ * ViewModel 이 소유하고 화면에는 [textState] 를 그대로 내려보낸다.
+ *
+ * 입력 시점 제한(자릿수·숫자 여부)과 타이핑 중 보정은 기존과 동일하게
+ * 각 화면의 InputTransformation 과 ViewModel 의 snapshotFlow 가 그대로 담당한다.
+ */
+@Stable
+class ClampedNumberFieldState(
+    private val min: Int,
+    private val max: Int,
+    initialValue: Int? = null,
+    /** 필드가 비어 있을 때 [applyChange]·[exceedsMaxAfter] 가 기준으로 삼는 값. */
+    private val emptyValue: Int = 0,
+) {
+    val textState = TextFieldState(initialValue?.toString().orEmpty())
+
+    val text: String
+        get() = textState.text.toString()
+
+    /** 현재 입력값. 비어 있으면 null. */
+    val value: Int?
+        get() = text.toIntOrNull()
+
+    /**
+     * 포커스 아웃·제출 시점에 [min]~[max] 로 보정하고 최종값을 돌려준다.
+     * 이미 범위 안이면 텍스트를 건드리지 않는다.
+     */
+    fun clampToRange(): Int {
+        val current = value
+        val clamped = (current ?: min).coerceIn(min, max)
+        if (current == null || current != clamped) {
+            setValue(clamped)
+        }
+        return clamped
+    }
+
+    /** 프리셋 버튼(+5, -10 …)으로 값을 더하고 보정된 최종값을 돌려준다. */
+    fun applyChange(change: Int): Int {
+        val updated = ((value ?: emptyValue) + change).coerceIn(min, max)
+        setValue(updated)
+        return updated
+    }
+
+    /** [change] 를 적용했을 때 상한을 넘는지. 스낵바 노출 여부 판단용. */
+    fun exceedsMaxAfter(change: Int): Boolean = (value ?: emptyValue) + change > max
+
+    fun setValue(value: Int) {
+        textState.setTextAndPlaceCursorAtEnd(value.toString())
+    }
+}

--- a/app/src/main/java/com/kiero/presentation/auth/kid/model/KidSignUpUiModel.kt
+++ b/app/src/main/java/com/kiero/presentation/auth/kid/model/KidSignUpUiModel.kt
@@ -1,11 +1,11 @@
 package com.kiero.presentation.auth.kid.model
 
 import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 import com.kiero.core.common.util.InputValidator
 import com.kiero.data.auth.model.AuthKidModel
 
-@Immutable
+@Stable
 data class KidSignUpUiModel(
     val firstName: TextFieldState = TextFieldState(),
     val lastName: TextFieldState = TextFieldState(),

--- a/app/src/main/java/com/kiero/presentation/auth/kid/state/KidSignupContract.kt
+++ b/app/src/main/java/com/kiero/presentation/auth/kid/state/KidSignupContract.kt
@@ -1,9 +1,9 @@
 package com.kiero.presentation.auth.kid.state
 
-import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 import com.kiero.presentation.auth.kid.model.KidSignUpUiModel
 
-@Immutable
+@Stable
 data class KidSignUpState(
     val kidSignUpUiModel: KidSignUpUiModel = KidSignUpUiModel(),
 )

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mission/ParentAddMissionScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mission/ParentAddMissionScreen.kt
@@ -107,7 +107,10 @@ fun ParentAddMissionScreen(
             .fillMaxSize()
             .background(color = KieroTheme.colors.black)
             .padding(paddingValues)
-            .noRippleClickable { focusManager.clearFocus() },
+            .noRippleClickable {
+                viewModel.validateAndFixReward()
+                focusManager.clearFocus()
+            },
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(15.dp),
     ) {
@@ -140,7 +143,7 @@ fun ParentAddMissionScreen(
         Spacer(modifier = Modifier.height(12.dp))
 
         MissionAwardSelect(
-            textFieldState = viewModel.awardTextFieldState,
+            textFieldState = viewModel.awardField.textState,
             onAwardClick = viewModel::onAwardClick,
         )
 

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mission/auto/ParentAutoResultScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mission/auto/ParentAutoResultScreen.kt
@@ -59,7 +59,7 @@ fun ParentAutoResultRoute(
         onCancelClick = viewModel::backToInputScreen,
         onShowDatePicker = viewModel::showDatePicker,
         onDismissDatePicker = viewModel::dismissDatePicker,
-        awardTextFieldState = viewModel.awardTextFieldState,
+        awardTextFieldState = viewModel.awardField.textState,
         paddingValues = paddingValues,
     )
 }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mission/auto/viewmodel/AutoMissionViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mission/auto/viewmodel/AutoMissionViewModel.kt
@@ -1,7 +1,5 @@
 package com.kiero.presentation.parent.screen.mission.auto.viewmodel
 
-import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -9,12 +7,14 @@ import com.kiero.core.analytic.tracker.Tracker
 import com.kiero.core.analytic.event.CreationMethod
 import com.kiero.core.analytic.event.KieroEvent
 import com.kiero.core.common.extension.track
+import com.kiero.core.common.state.ClampedNumberFieldState
 import com.kiero.core.localstorage.info.UserInfoManager
 import com.kiero.data.parent.mission.model.SuggestedMissionModel
 import com.kiero.data.parent.mission.repository.AutoMissionRepository
 import com.kiero.presentation.parent.screen.mission.auto.model.MissionUiModel
 import com.kiero.presentation.parent.screen.mission.auto.state.AutoMissionSideEffect
 import com.kiero.presentation.parent.screen.mission.auto.state.AutoMissionState
+import com.kiero.presentation.parent.screen.mission.component.model.MissionAwardDefaults
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -46,7 +46,11 @@ class AutoMissionViewModel @Inject constructor(
     private val _sideEffect = MutableSharedFlow<AutoMissionSideEffect>()
     val sideEffect: SharedFlow<AutoMissionSideEffect> = _sideEffect.asSharedFlow()
 
-    val awardTextFieldState = TextFieldState(initialText = "20")
+    val awardField = ClampedNumberFieldState(
+        min = MissionAwardDefaults.MIN_AWARD,
+        max = MissionAwardDefaults.MAX_AWARD,
+        initialValue = MissionAwardDefaults.DEFAULT_AWARD,
+    )
 
     init {
         observeAwardTextFieldChanges()
@@ -54,18 +58,18 @@ class AutoMissionViewModel @Inject constructor(
 
     private fun observeAwardTextFieldChanges() {
         viewModelScope.launch {
-            snapshotFlow { awardTextFieldState.text.toString() }
+            snapshotFlow { awardField.text }
                 .collectLatest{ text ->
                     val num = text.toIntOrNull()
 
                     if (num != null) {
-                        if (num > 500) {
-                            awardTextFieldState.setTextAndPlaceCursorAtEnd("500")
-                            _sideEffect.emit(AutoMissionSideEffect.ShowToast("최대 보상은 500개입니다."))
-                            updateMissionReward(500)
+                        if (num > MissionAwardDefaults.MAX_AWARD) {
+                            awardField.setValue(MissionAwardDefaults.MAX_AWARD)
+                            _sideEffect.emit(AutoMissionSideEffect.ShowToast("최대 보상은 ${MissionAwardDefaults.MAX_AWARD}개입니다."))
+                            updateMissionReward(MissionAwardDefaults.MAX_AWARD)
                         } else if (num == 0) {
-                            awardTextFieldState.setTextAndPlaceCursorAtEnd("1")
-                            updateMissionReward(1)
+                            awardField.setValue(MissionAwardDefaults.MIN_AWARD)
+                            updateMissionReward(MissionAwardDefaults.MIN_AWARD)
                         } else {
                             updateMissionReward(num)
                         }
@@ -73,8 +77,8 @@ class AutoMissionViewModel @Inject constructor(
                         if (text.isEmpty()) {
                             updateMissionReward(0)
                         } else {
-                            awardTextFieldState.setTextAndPlaceCursorAtEnd("1")
-                            updateMissionReward(1)
+                            awardField.setValue(MissionAwardDefaults.MIN_AWARD)
+                            updateMissionReward(MissionAwardDefaults.MIN_AWARD)
                         }
                     }
                 }
@@ -94,40 +98,24 @@ class AutoMissionViewModel @Inject constructor(
     }
 
     fun validateAndFixReward() {
-        val currentText = awardTextFieldState.text.toString()
-        val current = currentText.toIntOrNull()
+        val current = awardField.value
+        val clamped = awardField.clampToRange()
 
-        if (current == null || current < 1) {
-            awardTextFieldState.setTextAndPlaceCursorAtEnd("1")
-            updateMissionReward(1)
-        } else if (current > 500) {
-            awardTextFieldState.setTextAndPlaceCursorAtEnd("500")
-            updateMissionReward(500)
+        if (current == null || current != clamped) {
+            updateMissionReward(clamped)
         }
     }
 
     fun onAwardClick(change: Int) {
-        val currentText = awardTextFieldState.text.toString()
-        val current = if (currentText.isBlank()) 0 else currentText.toIntOrNull() ?: 0
-        val newValue = current + change
+        val exceedsMax = awardField.exceedsMaxAfter(change)
+        val newValue = awardField.applyChange(change)
 
-        when {
-            newValue > 500 -> {
-                awardTextFieldState.setTextAndPlaceCursorAtEnd("500")
-                viewModelScope.launch {
-                    _sideEffect.emit(AutoMissionSideEffect.ShowToast("최대 보상은 500개입니다."))
-                }
-                updateMissionReward(500)
-            }
-            newValue < 1 -> {
-                awardTextFieldState.setTextAndPlaceCursorAtEnd("1")
-                updateMissionReward(1)
-            }
-            else -> {
-                awardTextFieldState.setTextAndPlaceCursorAtEnd(newValue.toString())
-                updateMissionReward(newValue)
+        if (exceedsMax) {
+            viewModelScope.launch {
+                _sideEffect.emit(AutoMissionSideEffect.ShowToast("최대 보상은 ${MissionAwardDefaults.MAX_AWARD}개입니다."))
             }
         }
+        updateMissionReward(newValue)
     }
 
     fun updateNoticeText(text: String) {
@@ -235,7 +223,7 @@ class AutoMissionViewModel @Inject constructor(
 
         _state.value.currentMission?.let { mission ->
             _state.update { it.copy(selectedDate = mission.dueAt) }
-            awardTextFieldState.setTextAndPlaceCursorAtEnd(mission.reward.toString())
+            awardField.setValue(mission.reward)
         }
     }
 

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mission/component/model/MissionAwardModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mission/component/model/MissionAwardModel.kt
@@ -19,12 +19,4 @@ object MissionAwardDefaults {
         MissionAwardValue(5),
         MissionAwardValue(10)
     )
-
-    fun applyChange(currentValue: Int, change: Int): Int {
-        return (currentValue + change).coerceIn(MIN_AWARD, MAX_AWARD)
-    }
-
-    fun constrainValue(value: Int): Int {
-        return value.coerceIn(MIN_AWARD, MAX_AWARD)
-    }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/mission/viewmodel/ParentAddMissionViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/mission/viewmodel/ParentAddMissionViewModel.kt
@@ -1,7 +1,6 @@
 package com.kiero.presentation.parent.screen.mission.viewmodel
 
 import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -12,9 +11,11 @@ import com.kiero.core.analytic.event.CreationMethod
 import com.kiero.core.analytic.event.DueDateType
 import com.kiero.core.analytic.event.KieroEvent
 import com.kiero.core.common.extension.track
+import com.kiero.core.common.state.ClampedNumberFieldState
 import com.kiero.core.localstorage.info.UserInfoManager
 import com.kiero.data.parent.mission.model.UpdateMissionModel
 import com.kiero.data.parent.mission.repository.ParentMissionAddRepository
+import com.kiero.presentation.parent.screen.mission.component.model.MissionAwardDefaults
 import com.kiero.presentation.parent.screen.mission.navigation.MissionEdit
 import com.kiero.presentation.parent.screen.mission.state.ParentAddMissionSideEffect
 import com.kiero.presentation.parent.screen.mission.state.ParentAddMissionState
@@ -53,20 +54,22 @@ class ParentAddMissionViewModel @Inject constructor(
     val missionNameState = TextFieldState(
         initialText = editArgs?.name.orEmpty()
     )
-    val awardTextFieldState = TextFieldState(
-        initialText = editArgs?.reward?.takeIf { it > 0 }?.toString() ?: "20"
+    val awardField = ClampedNumberFieldState(
+        min = MissionAwardDefaults.MIN_AWARD,
+        max = MissionAwardDefaults.MAX_AWARD,
+        initialValue = editArgs?.reward?.takeIf { it > 0 } ?: MissionAwardDefaults.DEFAULT_AWARD,
     )
 
     init {
         viewModelScope.launch {
-            snapshotFlow { awardTextFieldState.text.toString() }.collectLatest { text ->
+            snapshotFlow { awardField.text }.collectLatest { text ->
                 val num = text.toIntOrNull()
                 if (num != null) {
-                    if (num > 500) {
-                        awardTextFieldState.setTextAndPlaceCursorAtEnd("500")
-                        _sideEffect.emit(ParentAddMissionSideEffect.ShowSnackbar("최대 보상은 500개입니다"))
+                    if (num > MissionAwardDefaults.MAX_AWARD) {
+                        awardField.setValue(MissionAwardDefaults.MAX_AWARD)
+                        _sideEffect.emit(ParentAddMissionSideEffect.ShowSnackbar("최대 보상은 ${MissionAwardDefaults.MAX_AWARD}개입니다"))
                     } else if (num == 0) {
-                        awardTextFieldState.setTextAndPlaceCursorAtEnd("1")
+                        awardField.setValue(MissionAwardDefaults.MIN_AWARD)
                     }
                 }
             }
@@ -112,33 +115,16 @@ class ParentAddMissionViewModel @Inject constructor(
     }
 
     fun validateAndFixReward() {
-        val currentText = awardTextFieldState.text.toString()
-        val current = currentText.toIntOrNull()
-
-        if (current == null || current < 1) {
-            awardTextFieldState.setTextAndPlaceCursorAtEnd("1")
-        } else if (current > 500) {
-            awardTextFieldState.setTextAndPlaceCursorAtEnd("500")
-        }
+        awardField.clampToRange()
     }
 
     fun onAwardClick(reward: Int) {
-        val currentText = awardTextFieldState.text.toString()
-        val current = if (currentText.isBlank()) 0 else currentText.toIntOrNull() ?: 0
-        val newValue = current + reward
+        val exceedsMax = awardField.exceedsMaxAfter(reward)
+        awardField.applyChange(reward)
 
-        when {
-            newValue > 500 -> {
-                awardTextFieldState.setTextAndPlaceCursorAtEnd("500")
-                viewModelScope.launch {
-                    _sideEffect.emit(ParentAddMissionSideEffect.ShowSnackbar("최대 보상은 500개입니다"))
-                }
-            }
-            newValue < 1 -> {
-                awardTextFieldState.setTextAndPlaceCursorAtEnd("1")
-            }
-            else -> {
-                awardTextFieldState.setTextAndPlaceCursorAtEnd(newValue.toString())
+        if (exceedsMax) {
+            viewModelScope.launch {
+                _sideEffect.emit(ParentAddMissionSideEffect.ShowSnackbar("최대 보상은 ${MissionAwardDefaults.MAX_AWARD}개입니다"))
             }
         }
     }
@@ -161,7 +147,7 @@ class ParentAddMissionViewModel @Inject constructor(
     private fun addMission() {
         viewModelScope.launch {
             val name   = missionNameState.text.toString().trim()
-            val reward = awardTextFieldState.text.toString().toIntOrNull()
+            val reward = awardField.value
             val dueAt  = _selectedDate.value
 
             if (!validate(name, reward, dueAt)) return@launch
@@ -202,7 +188,7 @@ class ParentAddMissionViewModel @Inject constructor(
         viewModelScope.launch {
             val missionId = editArgs?.missionId ?: return@launch
             val name      = missionNameState.text.toString().trim()
-            val reward    = awardTextFieldState.text.toString().toIntOrNull()
+            val reward    = awardField.value
             val dueAt     = _selectedDate.value
 
             if (!validate(name, reward, dueAt)) return@launch

--- a/app/src/main/java/com/kiero/presentation/parent/screen/reward/ParentRewardAddScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/reward/ParentRewardAddScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
-import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -33,7 +32,6 @@ import com.kiero.presentation.parent.navigation.ParentReward
 import com.kiero.presentation.parent.screen.reward.component.RewardNameTextField
 import com.kiero.presentation.parent.screen.reward.component.RewardPriceInfo
 import com.kiero.presentation.parent.screen.reward.component.RewardPriceSelect
-import com.kiero.presentation.parent.screen.reward.model.RewardPriceDefaults
 import com.kiero.presentation.parent.screen.reward.state.ParentRewardSideEffect
 import com.kiero.presentation.parent.screen.reward.viewmodel.ParentAddRewardViewModel
 
@@ -67,10 +65,11 @@ fun ParentRewardAddRoute(
     ParentRewardAddScreen(
         isLoading = uiState.isLoading,
         nameState = viewModel.nameState,
-        priceState = viewModel.priceState,
+        priceState = viewModel.priceField.textState,
         focusRequester = focusRequester,
         onSaveClick = viewModel::createReward,
         onCancelClick = navigateUp,
+        onPriceClick = viewModel::onPriceClick,
         onValidatePrice = viewModel::validateAndFixPrice
     )
 }
@@ -83,6 +82,7 @@ private fun ParentRewardAddScreen(
     focusRequester: FocusRequester,
     onSaveClick: () -> Unit,
     onCancelClick: () -> Unit,
+    onPriceClick: (Int) -> Unit,
     onValidatePrice: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -120,14 +120,7 @@ private fun ParentRewardAddScreen(
 
         RewardPriceSelect(
             textFieldState = priceState,
-            onPriceClick = { delta ->
-                val current = priceState.text.toString().toIntOrNull() ?: RewardPriceDefaults.DEFAULT_PRICE
-                val updated = (current + delta).coerceIn(
-                    RewardPriceDefaults.MIN_PRICE,
-                    RewardPriceDefaults.MAX_PRICE
-                )
-                priceState.setTextAndPlaceCursorAtEnd(updated.toString())
-            },
+            onPriceClick = onPriceClick,
             onValueAdjust = {
                 onValidatePrice()
             }
@@ -146,6 +139,7 @@ private fun ParentRewardAddScreenPreview() {
             focusRequester = remember { FocusRequester() },
             onSaveClick = {},
             onCancelClick = {},
+            onPriceClick = {},
             onValidatePrice = {}
         )
     }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/reward/ParentRewardEditScreen.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/reward/ParentRewardEditScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
-import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -33,7 +32,6 @@ import com.kiero.presentation.parent.navigation.ParentReward
 import com.kiero.presentation.parent.screen.reward.component.RewardNameTextField
 import com.kiero.presentation.parent.screen.reward.component.RewardPriceInfo
 import com.kiero.presentation.parent.screen.reward.component.RewardPriceSelect
-import com.kiero.presentation.parent.screen.reward.model.RewardPriceDefaults
 import com.kiero.presentation.parent.screen.reward.state.ParentRewardSideEffect
 import com.kiero.presentation.parent.screen.reward.viewmodel.ParentEditRewardViewModel
 
@@ -67,10 +65,11 @@ fun ParentRewardEditRoute(
     ParentRewardEditScreen(
         isLoading = uiState.isLoading,
         nameState = viewModel.nameState,
-        priceState = viewModel.priceState,
+        priceState = viewModel.priceField.textState,
         focusRequester = focusRequester,
         onSaveClick = viewModel::updateReward,
         onCancelClick = navigateUp,
+        onPriceClick = viewModel::onPriceClick,
         onValidatePrice = viewModel::validateAndFixPrice
     )
 }
@@ -83,6 +82,7 @@ private fun ParentRewardEditScreen(
     focusRequester: FocusRequester,
     onSaveClick: () -> Unit,
     onCancelClick: () -> Unit,
+    onPriceClick: (Int) -> Unit,
     onValidatePrice: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -120,12 +120,7 @@ private fun ParentRewardEditScreen(
 
         RewardPriceSelect(
             textFieldState = priceState,
-            onPriceClick = { delta ->
-                val current = priceState.text.toString().toIntOrNull() ?: 0
-                val updated = (current + delta).coerceIn(
-                    RewardPriceDefaults.MIN_PRICE,RewardPriceDefaults.MAX_PRICE)
-                priceState.setTextAndPlaceCursorAtEnd(updated.toString())
-            },
+            onPriceClick = onPriceClick,
             onValueAdjust = {
                 onValidatePrice()
             }
@@ -144,6 +139,7 @@ private fun ParentRewardEditScreenPreview() {
             focusRequester = remember { FocusRequester() },
             onSaveClick = {},
             onCancelClick = {},
+            onPriceClick = {},
             onValidatePrice = {}
         )
     }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/reward/viewmodel/ParentAddRewardViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/reward/viewmodel/ParentAddRewardViewModel.kt
@@ -1,13 +1,13 @@
 package com.kiero.presentation.parent.screen.reward.viewmodel
 
 import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kiero.core.analytic.event.KieroEvent
 import com.kiero.core.analytic.tracker.Tracker
 import com.kiero.core.common.extension.track
+import com.kiero.core.common.state.ClampedNumberFieldState
 import com.kiero.core.localstorage.info.UserInfoManager
 import com.kiero.data.parent.reward.repository.RewardRepository
 import com.kiero.presentation.parent.screen.reward.model.RewardPriceDefaults
@@ -30,7 +30,12 @@ class ParentAddRewardViewModel @Inject constructor(
     private val tracker: Tracker
 ) : ViewModel() {
     val nameState = TextFieldState()
-    val priceState = TextFieldState(RewardPriceDefaults.DEFAULT_PRICE.toString())
+    val priceField = ClampedNumberFieldState(
+        min = RewardPriceDefaults.MIN_PRICE,
+        max = RewardPriceDefaults.MAX_PRICE,
+        initialValue = RewardPriceDefaults.DEFAULT_PRICE,
+        emptyValue = RewardPriceDefaults.DEFAULT_PRICE,
+    )
 
     private val _state = MutableStateFlow(ParentRewardFormState())
     val state = _state.asStateFlow()
@@ -40,14 +45,14 @@ class ParentAddRewardViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            snapshotFlow { priceState.text.toString() }.collectLatest{ text ->
+            snapshotFlow { priceField.text }.collectLatest{ text ->
                 val num = text.toIntOrNull()
                 if (num != null) {
                     if (num > RewardPriceDefaults.MAX_PRICE) {
-                        priceState.edit { replace(0, length, RewardPriceDefaults.MAX_PRICE.toString()) }
+                        priceField.textState.edit { replace(0, length, RewardPriceDefaults.MAX_PRICE.toString()) }
                         _sideEffect.emit(ParentRewardSideEffect.ShowSnackBar("최대 보상은 ${RewardPriceDefaults.MAX_PRICE}개입니다"))
                     } else if (num == 0) {
-                        priceState.edit { replace(0, length, RewardPriceDefaults.MIN_PRICE.toString()) }
+                        priceField.textState.edit { replace(0, length, RewardPriceDefaults.MIN_PRICE.toString()) }
                     }
                 }
             }
@@ -57,7 +62,7 @@ class ParentAddRewardViewModel @Inject constructor(
     fun createReward() {
         validateAndFixPrice()
         val name = nameState.text.toString().trim()
-        val price = priceState.text.toString().toIntOrNull() ?: 0
+        val price = priceField.value ?: 0
 
         viewModelScope.launch {
             if (name.isEmpty()) {
@@ -86,14 +91,11 @@ class ParentAddRewardViewModel @Inject constructor(
         }
     }
 
-    fun validateAndFixPrice() {
-        val text = priceState.text.toString()
-        val currentPrice = text.toIntOrNull()
+    fun onPriceClick(change: Int) {
+        priceField.applyChange(change)
+    }
 
-        if (currentPrice == null || currentPrice < RewardPriceDefaults.MIN_PRICE) {
-            priceState.setTextAndPlaceCursorAtEnd(RewardPriceDefaults.MIN_PRICE.toString())
-        } else if (currentPrice > RewardPriceDefaults.MAX_PRICE) {
-            priceState.setTextAndPlaceCursorAtEnd(RewardPriceDefaults.MAX_PRICE.toString())
-        }
+    fun validateAndFixPrice() {
+        priceField.clampToRange()
     }
 }

--- a/app/src/main/java/com/kiero/presentation/parent/screen/reward/viewmodel/ParentEditRewardViewModel.kt
+++ b/app/src/main/java/com/kiero/presentation/parent/screen/reward/viewmodel/ParentEditRewardViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import com.kiero.core.common.state.ClampedNumberFieldState
 import com.kiero.core.localstorage.info.UserInfoManager
 import com.kiero.data.parent.reward.repository.RewardRepository
 import com.kiero.presentation.parent.screen.reward.model.RewardPriceDefaults
@@ -30,7 +31,10 @@ class ParentEditRewardViewModel @Inject constructor(
     private val couponId = savedStateHandle.toRoute<RewardEdit>().couponId
 
     val nameState = TextFieldState()
-    val priceState = TextFieldState()
+    val priceField = ClampedNumberFieldState(
+        min = RewardPriceDefaults.MIN_PRICE,
+        max = RewardPriceDefaults.MAX_PRICE,
+    )
 
     private val _state = MutableStateFlow(ParentRewardFormState())
     val state = _state.asStateFlow()
@@ -49,7 +53,7 @@ class ParentEditRewardViewModel @Inject constructor(
             rewardRepository.getCoupons(childId).onSuccess { list ->
                 list.find { it.couponId == couponId }?.let { reward ->
                     nameState.setTextAndPlaceCursorAtEnd(reward.name)
-                    priceState.setTextAndPlaceCursorAtEnd(reward.price.toString())
+                    priceField.setValue(reward.price)
                 }
             }
             _state.update { it.copy(isLoading = false) }
@@ -58,7 +62,7 @@ class ParentEditRewardViewModel @Inject constructor(
 
     fun updateReward() {
         val name = nameState.text.toString().trim()
-        val price = priceState.text.toString().toIntOrNull() ?: 0
+        val price = priceField.value ?: 0
 
         viewModelScope.launch {
             if (name.isEmpty()) {
@@ -83,16 +87,17 @@ class ParentEditRewardViewModel @Inject constructor(
         }
     }
 
+    fun onPriceClick(change: Int) {
+        priceField.applyChange(change)
+    }
+
     fun validateAndFixPrice() {
-        val text = priceState.text.toString()
-        val currentPrice = text.toIntOrNull() ?: 0
-        if (currentPrice > RewardPriceDefaults.MAX_PRICE) {
-            priceState.setTextAndPlaceCursorAtEnd(RewardPriceDefaults.MAX_PRICE.toString())
+        val exceedsMax = (priceField.value ?: 0) > RewardPriceDefaults.MAX_PRICE
+        priceField.clampToRange()
+        if (exceedsMax) {
             viewModelScope.launch {
                 _sideEffect.emit(ParentRewardSideEffect.ShowSnackBar("최대 보상은 ${RewardPriceDefaults.MAX_PRICE}개입니다"))
             }
-        } else if (text.isEmpty() || currentPrice < RewardPriceDefaults.MIN_PRICE) {
-            priceState.setTextAndPlaceCursorAtEnd(RewardPriceDefaults.MIN_PRICE.toString())
         }
     }
 }

--- a/app/src/main/java/com/kiero/presentation/signup/parent/model/ParentSignUpChildInfoUiModel.kt
+++ b/app/src/main/java/com/kiero/presentation/signup/parent/model/ParentSignUpChildInfoUiModel.kt
@@ -1,11 +1,11 @@
 package com.kiero.presentation.signup.parent.model
 
 import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 import com.kiero.core.common.util.InputValidator
 import com.kiero.data.parent.signup.model.ParentSignUpModel
 
-@Immutable
+@Stable
 data class ParentSignUpChildInfoUiModel(
     val code: String = "",
     val childLastName: TextFieldState = TextFieldState(),

--- a/app/src/main/java/com/kiero/presentation/signup/parent/state/ParentSignUpContract.kt
+++ b/app/src/main/java/com/kiero/presentation/signup/parent/state/ParentSignUpContract.kt
@@ -1,11 +1,11 @@
 package com.kiero.presentation.signup.parent.state
 
-import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 import com.kiero.presentation.signup.parent.model.ParentInfoUiModel
 import com.kiero.presentation.signup.parent.model.ParentSignUpChildInfoUiModel
 import com.kiero.presentation.signup.parent.model.ParentSignUpStep
 
-@Immutable
+@Stable
 data class ParentSignUpState(
     val parentInfo: ParentInfoUiModel = ParentInfoUiModel(),
     val childInfo: ParentSignUpChildInfoUiModel = ParentSignUpChildInfoUiModel(),


### PR DESCRIPTION
## ISSUE
- closed #202 

## ❗ WORK DESCRIPTION
[참고 블로그](https://velog.io/@purang/TextFieldState-%EB%8B%A4%EC%A4%91-%ED%95%84%EB%93%9C-%ED%8F%BC%EC%9D%80-%EC%96%B4%EB%96%BB%EA%B2%8C-%EA%B4%80%EB%A6%AC%ED%95%A0%EA%B9%8C)

## 배경
`TextFieldState` 사용처 23곳을 전수 확인한 결과, 실제 화면은 모두 ViewModel이 상태를 직접 보유하는 패턴 A였고 `rememberTextFieldState()`는 `@Preview`에서만 사용되고 있었습니다.

현재 교차 필드 실시간 검증이나 프로세스 종료 후 복원 요구가 없어 상태 소유 패턴은 유지하고, 중복된 숫자 필드 검증·보정 로직과 잘못된 Compose 안정성 계약만 정리했습니다.

## 변경 사항
* `ClampedNumberFieldState`를 도입해 숫자 입력 상태와 보정 로직을 공통화
* 4개 ViewModel과 2개 Composable에 중복된 검증·보정 로직 통합
* `min / max / emptyValue`를 상태 홀더의 파라미터로 분리

  * 화면별 빈 값 기준을 유지하기 위해 `emptyValue`를 통일하지 않음
  * 보상 추가: `DEFAULT_PRICE`
  * 보상 수정·미션: `0`
* 사용되지 않던 헬퍼 함수 및 하드코딩된 임계값 정리
* mutable한 `TextFieldState`를 포함한 `@Immutable` 타입 4개를 `@Stable`로 수정

## 동작 변경 없음
기존 동작을 유지하기 위해 다음 조건을 그대로 보존했습니다.

* `clampToRange()`

  * `null` 또는 최솟값 미만은 최솟값으로 보정
  * 최댓값 초과는 최댓값으로 보정
  * 범위 내 값은 유지
  * 기존과 동일하게 필요한 경우에만 텍스트를 갱신
* `applyChange()`

  * 변경값을 적용한 뒤 `min ~ max` 범위로 제한
* `exceedsMaxAfter()`

  * 빈 값은 `emptyValue`를 기준으로 최댓값 초과 여부를 판단
* `AutoMissionViewModel.validateAndFixReward()`

  * 실제 보정이 발생한 경우에만 `updateMissionReward()` 호출
* `ParentAddRewardViewModel`

  * 기존 `edit { replace(0, length, ...) }` 동작 유지

## 이번 PR에서 제외한 내용
* `InputTransformation` 기반 입력 시점 차단

  * 기존의 `600 입력 → 500으로 보정 + 스낵바` UX가 변경되므로 별도 기획 논의로 보류
* `SavedStateHandle` 연동

  * 현재 폼이 짧고 프로세스 종료 복원 요구가 없어 적용하지 않음
  * 필요할 경우 `ClampedNumberFieldState` 내부에서 확장 가능
* 자동 미션 결과 화면의 배경 탭 보정

  * 텍스트 보정을 넘어 페이저 내부 미션 데이터까지 변경하므로 별도 판단 필요

## 검증
* `compileParentDevDebugKotlin` 통과
* `compileChildDevDebugKotlin` 통과
* 리팩토링 전후 로직

## 📢 TO REVIEWERS
- 리뷰어에게 전달해야 하는 말

## 📸 SCREENSHOT
<img src="" width="300" />
<!-- video src="" witdh="300"/>-->
